### PR TITLE
Add iCloud download option for photo exports

### DIFF
--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -47,9 +47,10 @@ export async function runOsxphotosExportImages(
     "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
 
   const cmd = `"${osxphotosPath}" export "${imagesDir}" \
---uuid-from-file "${uuidsFile}" \
---filename "${filenameTemplate}" \
---convert-to-jpeg --jpeg-ext jpg`;
+  --uuid-from-file "${uuidsFile}" \
+  --download-missing \
+  --filename "${filenameTemplate}" \
+  --convert-to-jpeg --jpeg-ext jpg`;
 
   await execCommand(cmd, "osxphotos image export failed:");
 }


### PR DESCRIPTION
## Summary
- ensure the backend downloads iCloud photos during export

## Testing
- `npm test` *(fails: Cannot find module '/workspace/photo-filter/backend/node_modules/.bin/jest')*
- `npm ci` *(fails: osx-tag build error – missing Foundation.framework)*

------
https://chatgpt.com/codex/tasks/task_e_685ef07d69f08330be8bf959279b3d08