### PR TITLE
Add top‑N export by score

### DIFF
--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -1,0 +1,104 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { fileURLToPath } from 'url';
+import { runPythonScript } from '../../utils/run-python-script.js';
+import { runOsxphotosExportImages } from '../../utils/export-images.js';
+import { formatPreciseTimestamp, getNestedProperty } from '../../utils/helpers.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Aesthetic score attributes to process
+export const AESTHETIC_ATTRIBUTES = [
+  'overall',
+  'curation',
+  'highlight_visibility',
+  'behavioral',
+  'harmonious_color',
+  'immersiveness',
+  'interaction',
+  'interesting_subject',
+  'pleasant_camera_tilt',
+  'pleasant_composition',
+  'pleasant_lighting',
+  'pleasant_pattern',
+  'pleasant_perspective',
+  'pleasant_post_processing',
+  'pleasant_reflection',
+  'pleasant_symmetry',
+  'sharply_focused_subject',
+  'tastefully_blurred',
+  'well_chosen_subject',
+  'well_framed_subject',
+  'well_timed_shot',
+];
+
+export async function exportTopN(req, res) {
+  try {
+    const albumUUID = req.params.albumUUID;
+    const { n, persons = [] } = req.body || {};
+    const topN = Math.max(parseInt(n, 10) || 1, 1);
+
+    const dataDir = path.join(__dirname, '..', '..', 'data');
+    const albumDir = path.join(dataDir, 'albums', albumUUID);
+    const photosJSON = path.join(albumDir, 'photos.json');
+    const imagesDir = path.join(albumDir, 'images');
+    const exportBase = path.join(__dirname, '..', '..', 'exports', albumUUID);
+
+    const venvDir = path.join(__dirname, '..', '..', 'venv');
+    const python = path.join(venvDir, 'bin', 'python3');
+    const pyExport = path.join(__dirname, '..', '..', 'scripts', 'export_photos_in_album.py');
+    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
+
+    await fs.ensureDir(imagesDir);
+    if (!(await fs.pathExists(photosJSON))) {
+      await runPythonScript(python, pyExport, [albumUUID], photosJSON);
+      await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
+    }
+
+    const photos = await fs.readJson(photosJSON);
+    photos.forEach((p) => {
+      p.originalName = path.parse(p.original_filename).name;
+      const ts = formatPreciseTimestamp(p.date);
+      p.exportedFilename = `${ts}-${p.originalName}.jpg`;
+    });
+
+    let filtered = photos;
+    if (persons.length > 0) {
+      filtered = photos.filter((p) => {
+        const names = Array.isArray(p.persons) ? p.persons : [];
+        return persons.every((name) => names.includes(name));
+      });
+    }
+
+    const personKey = persons.length > 0 ? persons.join('_') : 'all';
+    const personDir = path.join(exportBase, personKey);
+    await fs.ensureDir(personDir);
+
+    for (const attr of AESTHETIC_ATTRIBUTES) {
+      const scoreKey = `score.${attr}`;
+      const sorted = [...filtered].sort((a, b) => {
+        const va = getNestedProperty(a, scoreKey);
+        const vb = getNestedProperty(b, scoreKey);
+        if (va === undefined || va === null) return 1;
+        if (vb === undefined || vb === null) return -1;
+        return vb - va;
+      });
+      const topPhotos = sorted.slice(0, topN);
+      const attrDir = path.join(personDir, attr);
+      await fs.ensureDir(attrDir);
+      for (const photo of topPhotos) {
+        const src = path.join(imagesDir, photo.exportedFilename);
+        const dest = path.join(attrDir, photo.exportedFilename);
+        if (await fs.pathExists(src)) {
+          await fs.copy(src, dest);
+        }
+      }
+    }
+
+    return res.json({ message: `Exported top ${topN} photos to ${personDir}` });
+  } catch (err) {
+    console.error('exportTopN error:', err);
+    return res.status(500).json({ errors: [{ detail: 'Internal Server Error' }] });
+  }
+}

--- a/backend/controllers/api/index.js
+++ b/backend/controllers/api/index.js
@@ -2,3 +2,4 @@
 
 export { getAlbumsData, getAlbumById } from "./albums-controller.js";
 export { getPhotosByAlbumData } from "./photos-controller.js";
+export { exportTopN } from "./export-top-n.js";

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -8,6 +8,7 @@ import {
   getAlbumsData,
   getAlbumById,
   getPhotosByAlbumData,
+  exportTopN,
 } from "../controllers/api/index.js";
 import {
   getPeopleInAlbum,
@@ -41,6 +42,11 @@ apiRouter.get("/albums/:albumUUID/person/:personName", getPhotosByPerson);
 //   TIME-INDEX ENDPOINT
 // ======================
 apiRouter.get("/time-index", getTimeIndex);
+
+// ======================
+//   Export Top‑N Endpoint
+// ======================
+apiRouter.post("/albums/:albumUUID/export-top-n", exportTopN);
 
 // ======================
 //   REFRESH Endpoint

--- a/frontend/photo-filter-frontend/app/controllers/albums/album.js
+++ b/frontend/photo-filter-frontend/app/controllers/albums/album.js
@@ -4,6 +4,7 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import { inject as service } from '@ember/service';
+import config from 'photo-filter-frontend/config/environment';
 
 export default class AlbumsAlbumController extends Controller {
   @service router;
@@ -13,6 +14,9 @@ export default class AlbumsAlbumController extends Controller {
   @tracked order = 'desc';
   @tracked persons = [];
   @tracked dates = [];
+
+  // Export Top-N
+  @tracked exportN = 5;
 
   // Pagination
   @tracked page = 1;
@@ -135,6 +139,32 @@ export default class AlbumsAlbumController extends Controller {
     this.order = event.target.value;
     this.page = 1;
     this.updateQueryParams();
+  }
+
+  @action
+  updateExportN(event) {
+    const value = parseInt(event.target.value, 10);
+    if (!isNaN(value) && value > 0) {
+      this.exportN = value;
+    }
+  }
+
+  @action
+  async exportTopN() {
+    const albumId = this.router.currentRoute.params.album_id;
+    const apiHost = config.APP.apiHost;
+    const body = {
+      n: this.exportN,
+      persons: this.persons,
+    };
+
+    await fetch(`${apiHost}/api/albums/${albumId}/export-top-n`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
   }
 
   updateQueryParams() {

--- a/frontend/photo-filter-frontend/app/templates/albums/album.hbs
+++ b/frontend/photo-filter-frontend/app/templates/albums/album.hbs
@@ -15,6 +15,19 @@
   {{/each}}
 </div>
 
+<div class="flex justify-center mb-4 gap-2">
+  <input
+    type="number"
+    min="1"
+    class="input input-xs w-16"
+    value={{this.exportN}}
+    {{on "input" this.updateExportN}}
+  />
+  <button type="button" class="btn btn-xs" {{on "click" this.exportTopN}}>
+    Export Top N
+  </button>
+</div>
+
 <!-- Remove the did-update modifier -->
 <div>
   <PhotoGrid


### PR DESCRIPTION
## Summary
- enable exporting the top N photos for a set of aesthetic scores
- expose new `POST /api/albums/:albumUUID/export-top-n` endpoint
- allow choosing N and exporting directly from the album UI

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*

------
https://chatgpt.com/codex/tasks/task_e_685f41d799a48330b36030c31ba9c344