### PR TITLE
Fix Jest path for backend tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,8 +23,8 @@
     "setup": "node ./scripts/setup.js",
     "start": "node server.js",
     "dev": "nodemon --ignore 'data/*' server.js",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest",
-    "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
+    "test": "node --experimental-vm-modules ../node_modules/.bin/jest",
+    "test:watch": "node --experimental-vm-modules ../node_modules/.bin/jest --watch",
     "generate-overview": "../generate-overview.sh",
     "postinstall": "node ./scripts/setup.js"
   }


### PR DESCRIPTION
## Summary
- reference root workspace `jest` in backend test scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d82947a248330bab0b6a4b1ade1cc