### PR TITLE
Lazy export of album images

### DIFF
--- a/backend/utils/top-uuids.js
+++ b/backend/utils/top-uuids.js
@@ -1,0 +1,19 @@
+import { getNestedProperty } from './helpers.js';
+
+export function topUUIDsByAttributes(photos, attributes, n = 50) {
+  const unique = new Set();
+  for (const attr of attributes) {
+    const scoreKey = `score.${attr}`;
+    const sorted = [...photos].sort((a, b) => {
+      const va = getNestedProperty(a, scoreKey);
+      const vb = getNestedProperty(b, scoreKey);
+      if (va === undefined || va === null) return 1;
+      if (vb === undefined || vb === null) return -1;
+      return vb - va;
+    });
+    for (const photo of sorted.slice(0, n)) {
+      unique.add(photo.uuid);
+    }
+  }
+  return [...unique];
+}


### PR DESCRIPTION
## Summary
- export only top 50 photos for each aesthetic aspect when albums are first synced
- export missing images on demand
- support exporting arbitrary UUID sets

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6872cd3136808330a6c460ac6941f144