### PR TITLE
Add customizable video background

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ ffmpeg -f concat -safe 0 -i formatted_list.txt \
 - **Change the Output Codec:**  
   Prefer a different codec (e.g., H.264 for smaller file sizes)? Replace \`-c:v prores -pix_fmt yuv422p\` with \`-c:v libx264 -crf 18\`.
 
-- **Further Refinements:**  
+- **Further Refinements:**
   If you have specific creative requirements (e.g., adding transitions, stabilizing footage, or applying filters), you can incorporate those steps into your ffmpeg pipeline or perform them later in your video editing software.
+
+- **Automate with `create-video.sh`:** Run `sh scripts/create-video.sh [-b COLOR] [dir]` to generate a padded ProRes video. The `-b` option lets you choose a background color. Use `transparent` (the default) for alpha padding.
 
 ## Installation and Setup
 

--- a/scripts/create-video.sh
+++ b/scripts/create-video.sh
@@ -6,7 +6,11 @@
 # invoke this script to generate a single .mov video file from all .jpg images.
 #
 # Usage:
-#   sh create-video.sh [directory-of-jpg-images]
+#   sh create-video.sh [-b COLOR] [directory-of-jpg-images]
+#
+# Options:
+#   -b COLOR  Background color for padding. Use "transparent" to keep
+#              alpha transparency. Defaults to "transparent".
 #
 # If no directory is provided, the script will default to the current directory.
 #
@@ -25,6 +29,27 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
+# Default background color is transparent
+BG_COLOR="transparent"
+
+# Parse options
+while getopts ":b:h" opt; do
+  case "$opt" in
+    b)
+      BG_COLOR="$OPTARG"
+      ;;
+    h)
+      echo "Usage: sh create-video.sh [-b COLOR] [directory]" >&2
+      exit 0
+      ;;
+    *)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 # 1. Handle optional directory argument or default to current directory
 IMAGES_DIR="${1:-$(pwd)}"
 
@@ -39,14 +64,14 @@ echo "Working in directory: $IMAGES_DIR"
 
 # 2. Ensure all images have the correct orientation
 echo "1) Ensuring all .jpg images have correct orientation..."
-mogrify -auto-orient *.jpg || {
+mogrify -auto-orient ./*.jpg || {
   echo "No .jpg files found or mogrify command failed."
   exit 1
 }
 
 # 3. Generate a file list of .jpg images
 echo "2) Generating file_list.txt for ffmpeg..."
-ls -1 *.jpg > file_list.txt
+ls -1 ./*.jpg > file_list.txt
 
 # 4. Convert file_list.txt into ffmpeg's concat format
 echo "   Converting list to ffmpeg concat format -> formatted_list.txt"
@@ -74,13 +99,21 @@ echo "   Found dimensions: $WIDTH x $HEIGHT"
 #    -framerate is set to 16, but you can change it to your preference
 OUTPUT_FILE="output_preserved_aspect.mov"
 echo "4) Creating ProRes video ($OUTPUT_FILE) with preserved aspect ratio..."
+
+# If transparent background requested, use ProRes 4444 and alpha channel
+PAD_COLOR="$BG_COLOR"
+CODEC_ARGS=(-c:v prores -pix_fmt yuv422p)
+if [ "$BG_COLOR" = "transparent" ]; then
+  PAD_COLOR="0x00000000"
+  CODEC_ARGS=(-c:v prores_ks -profile:v 4444 -pix_fmt yuva444p10le)
+fi
+
 ffmpeg \
   -f concat -safe 0 \
   -i formatted_list.txt \
-  -vf "scale='min(iw*${HEIGHT}/ih,${WIDTH})':${HEIGHT},setsar=1,pad=${WIDTH}:${HEIGHT}:(${WIDTH}-iw)/2:(${HEIGHT}-ih)/2" \
+  -vf "scale='min(iw*${HEIGHT}/ih,${WIDTH})':${HEIGHT},setsar=1,pad=${WIDTH}:${HEIGHT}:(${WIDTH}-iw)/2:(${HEIGHT}-ih)/2:color=${PAD_COLOR}" \
   -framerate 16 \
-  -c:v prores \
-  -pix_fmt yuv422p \
+  "${CODEC_ARGS[@]}" \
   "$OUTPUT_FILE"
 
 echo "Done! Created video: $OUTPUT_FILE"


### PR DESCRIPTION
## Summary
- allow `scripts/create-video.sh` to accept `-b` to set pad color
- support transparent padding via ProRes 4444
- document how to use `create-video.sh` in README

## Testing
- `shellcheck scripts/create-video.sh`
- `npm test` *(fails: Cannot find module '/workspace/photo-filter/backend/node_modules/.bin/jest')*


------
https://chatgpt.com/codex/tasks/task_e_687919b52fc08330ae77d27cd4ec421a