### PR TITLE
Improve transparency handling in create-video script

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ffmpeg -f concat -safe 0 -i formatted_list.txt \
 - **Further Refinements:**
   If you have specific creative requirements (e.g., adding transitions, stabilizing footage, or applying filters), you can incorporate those steps into your ffmpeg pipeline or perform them later in your video editing software.
 
-- **Automate with `create-video.sh`:** Run `sh scripts/create-video.sh [-b COLOR] [dir]` to generate a padded ProRes video. The `-b` option lets you choose a background color. Use `transparent` (the default) for alpha padding.
+- **Automate with `create-video.sh`:** Run `sh scripts/create-video.sh [-b COLOR] [-r FPS] [dir]` to generate a padded ProRes video. The `-b` option lets you choose a background color (use `transparent` for alpha padding). `-r` sets the frame rate (defaults to 16 fps).
 
 ## Installation and Setup
 


### PR DESCRIPTION
## Summary
- support a `-r` option for setting fps in `create-video.sh`
- refine transparent padding filter chain and codec
- document the new usage in README

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68794a948fd0833088bdd76514b50e98