### PR TITLE
Fix ffmpeg options in create-video script

### DIFF
--- a/scripts/create-video.sh
+++ b/scripts/create-video.sh
@@ -103,9 +103,9 @@ fi
 
 # Use the same frame rate for input and output to avoid dropped frames
 ffmpeg -hide_banner -y \
-  -framerate "$FPS" -f concat -safe 0 -i formatted_list.txt \
+  -f concat -safe 0 -i formatted_list.txt \
   -vf "$FILTER" \
-  -r "$FPS" -vsync vfr \
+  -r "$FPS" \
   "${CODEC[@]}" \
   "$OUTPUT"
 


### PR DESCRIPTION
## Summary
- fix ffmpeg command in `create-video.sh` when using the concat demuxer

## Testing
- `bash ../scripts/create-video.sh -b transparent -s` *(with sample images)*
- `npm install` *(fails: cannot compile osx-tag on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68798b71894c83309598b041f8898bed