### PR TITLE
Fix dropped frames in create-video

### DIFF
--- a/scripts/create-video.sh
+++ b/scripts/create-video.sh
@@ -103,9 +103,9 @@ fi
 
 # Use the same frame rate for input and output to avoid dropped frames
 ffmpeg -hide_banner -y \
-  -f concat -safe 0 -i formatted_list.txt \
+  -framerate "$FPS" -f concat -safe 0 -i formatted_list.txt \
   -vf "$FILTER" \
-  -r "$FPS" \
+  -r "$FPS" -fps_mode cfr \
   "${CODEC[@]}" \
   "$OUTPUT"
 


### PR DESCRIPTION
## Summary
- preserve input FPS while encoding video

## Testing
- `npm run test` *(fails: cannot find module 'jest')*
- `npm run test:frontend` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_68798f08b6208330badf937d81c9ab57