### PR TITLE
Fix index template handling and dev watcher ignores

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "setup": "node ./scripts/setup.js",
     "start": "node server.js",
-    "dev": "nodemon --ignore 'data/*' server.js",
+    "dev": "nodemon --ignore 'data/**' server.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
     "generate-overview": "../generate-overview.sh",

--- a/backend/utils/index-refresh.js
+++ b/backend/utils/index-refresh.js
@@ -28,9 +28,8 @@ export async function ensureFilenameIndexFresh() {
     await fs.ensureDir(libDir);
     const mtime = await getPhotosLibraryLastModified().catch(() => null);
     const logTemplate = () => {
-      let msg = `[index] template in use: ${TEMPLATE}`;
-      if (JPEG_EXT) msg += ` (jpeg-ext: ${JPEG_EXT})`;
-      console.log(msg);
+      console.log("[index] template in use:", TEMPLATE);
+      if (JPEG_EXT) console.log("[index] jpeg extension:", JPEG_EXT);
     };
     if (!mtime) {
       logTemplate();

--- a/package.json
+++ b/package.json
@@ -18,15 +18,15 @@
     "lint:frontend": "npm --prefix frontend/photo-filter-frontend run lint",
     "generate-overview": "bash generate-overview.sh",
     "bootstrap:dev": "bash scripts/dev_bootstrap.sh",
-    "build:filename-index": "bash -lc 'P=backend/venv/bin/python3; [ -x \"$P\" ] || P=$(command -v python3); T=\"$FILENAME_TEMPLATE\"; J=\"$JPEG_EXT\"; ARGS=(scripts/build_filename_index.py --output backend/data/library/filename-index.json); if [ -n \"$T\" ]; then ARGS+=(--template \"$T\"); fi; if [ -n \"$J\" ]; then ARGS+=(--jpeg-ext \"$J\"); fi; \"$P\" \"${ARGS[@]}\"'",
-    "super-dev": "npm run bootstrap:dev && concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"bash -lc 'PYTHON_BIN=$(pwd)/backend/venv/bin/python3 FILENAME_TEMPLATE='\"'\"'{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}{ext}'\"'\"' OSXPHOTOS_BIN=$(pwd)/backend/venv/bin/osxphotos npm run watch:backend'\" \"npm run watch:frontend\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
+    "build:filename-index": "bash -lc 'P=backend/venv/bin/python3; [ -x \"$P\" ] || P=$(command -v python3); \"$P\" scripts/build_filename_index.py --output backend/data/library/filename-index.json ${FILENAME_TEMPLATE:+--template \"$FILENAME_TEMPLATE\"} ${JPEG_EXT:+--jpeg-ext \"$JPEG_EXT\"}'",
+    "super-dev": "npm run bootstrap:dev && concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"npm run watch:backend\" \"npm run watch:frontend\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
     "check:docs": "node scripts/check_template_consistency.mjs",
     "precommit": "npm run check:docs",
-    "watch:backend": "nodemon --watch backend --ignore backend/data --ext js,ts,hbs,sh,md --exec \"npm run start:backend\"",
+    "watch:backend": "nodemon --watch backend --ignore 'backend/data/**' --ext js,ts,hbs,sh,md --exec \"npm run start:backend\"",
     "watch:frontend": "npm --prefix frontend/photo-filter-frontend run start",
     "watch:test:backend": "npm exec -w backend jest -- --watch || echo 'No watch test script for backend'",
     "watch:test:frontend": "npm --prefix frontend/photo-filter-frontend run test:ember -- --server",
-    "watch:overview": "nodemon --watch backend --watch frontend --ext js,ts,hbs,sh,md --ignore project-overview.txt --exec \"npm run generate-overview\""
+    "watch:overview": "nodemon --watch backend --watch frontend --ext js,ts,hbs,sh,md --ignore 'backend/data/**' --ignore project-overview.txt --exec \"npm run generate-overview\""
   },
   "workspaces": [
     "backend",


### PR DESCRIPTION
## Summary
- make filename index builder compatible with older osxphotos and log version info
- sanitize env vars and log template usage in index refresher
- remove template env from super-dev and fix nodemon ignore globs

## Testing
- `npm install` *(fails: cannot find Foundation.framework)*
- `npx update-browserslist-db@latest` *(prompts to install; not executed)*
- `npm run super-dev` *(canceled during bootstrap before index output)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf8214888330af559f8357017121