### PR TITLE
Pin osxphotos fork and default to jpg normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generate-overview": "bash generate-overview.sh",
     "bootstrap:dev": "bash scripts/dev_bootstrap.sh",
     "build:filename-index": "bash -lc 'P=backend/venv/bin/python3; [ -x \"$P\" ] || P=$(command -v python3); \"$P\" scripts/build_filename_index.py --output backend/data/library/filename-index.json ${FILENAME_TEMPLATE:+--template \"$FILENAME_TEMPLATE\"} ${JPEG_EXT:+--jpeg-ext \"$JPEG_EXT\"}'",
-    "super-dev": "npm run bootstrap:dev && concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"npm run watch:backend\" \"npm run watch:frontend\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
+    "super-dev": "JPEG_EXT=jpg npm run bootstrap:dev && concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"npm run watch:backend\" \"npm run watch:frontend\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
     "check:docs": "node scripts/check_template_consistency.mjs",
     "precommit": "npm run check:docs",
     "watch:backend": "nodemon --watch backend --ignore 'backend/data/**' --ext js,ts,hbs,sh,md --exec \"npm run start:backend\"",

--- a/scripts/build_filename_index.py
+++ b/scripts/build_filename_index.py
@@ -13,7 +13,7 @@ from osxphotos import PhotosDB, __version__ as osxphotos_version
 DEFAULT_TEMPLATE = "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}{ext}"
 
 def render_key(photo, template: str, jpeg_ext: str | None) -> str:
-    # Older osxphotos versions (e.g., 0.72.1) do not support ``none_str``.
+    # Some upstream versions don't support none_str; fallback cleanly
     try:
         parts = photo.render_template(template, none_str="")
     except TypeError:

--- a/scripts/dev_bootstrap.sh
+++ b/scripts/dev_bootstrap.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
 # 1) ensure venv
 if [[ ! -x "$ROOT_DIR/backend/venv/bin/python3" ]]; then
@@ -9,13 +10,18 @@ if [[ ! -x "$ROOT_DIR/backend/venv/bin/python3" ]]; then
   python3 -m venv "$ROOT_DIR/backend/venv"
 fi
 
-# 2) ensure osxphotos in venv
+# 2) install osxphotos fork in venv
 echo "[bootstrap] installing osxphotos (and pip upgrade)"
-"$ROOT_DIR/backend/venv/bin/pip" install --upgrade pip osxphotos
+OSXPHOTOS_FORK_SPEC="git+https://github.com/openhouse/osxphotos.git@0a9f561#egg=osxphotos"
+"$ROOT_DIR/backend/venv/bin/python3" -m pip install -U pip
+"$ROOT_DIR/backend/venv/bin/python3" -m pip install -U --force-reinstall "${OSXPHOTOS_FORK_SPEC}"
+"$ROOT_DIR/backend/venv/bin/python3" - <<'PY'
+from osxphotos import __version__ as v
+print(f"[bootstrap] osxphotos version installed: {v}")
+PY
 
-# 3) build filename index with venv python
+# 3) build filename index with default JPEG normalization
 echo "[bootstrap] building filename index"
-"$ROOT_DIR/backend/venv/bin/python3" "$ROOT_DIR/scripts/build_filename_index.py" \
-  --output "$ROOT_DIR/backend/data/library/filename-index.json" || true
+JPEG_EXT="${JPEG_EXT:-jpg}" npm run build:filename-index
 
 echo "[bootstrap] done"


### PR DESCRIPTION
## Summary
- force dev bootstrap to reinstall osxphotos fork and emit installed version
- default super-dev pipeline to .jpg extension normalization
- fall back when osxphotos lacks `none_str` and log osxphotos version during index build

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*
- `npm install` *(fails: cannot find Foundation.framework while building osx-tag)*

------
https://chatgpt.com/codex/tasks/task_e_6897ef13943c833091a7d54cf9177049