### PR TITLE
Index exported filenames and log missing images

### DIFF
--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -87,13 +87,35 @@ export const getPhotosByAlbumData = async (req, res) => {
     /* (2) Load data & enrich */
     let photos = await fs.readJson(photosJSON);
 
+    // Build an index of actual files we exported:
+    // key = lowercased basename (no extension), value = full filename (with extension)
+    const exportedNames = (await fs.pathExists(imagesDir))
+      ? await fs.readdir(imagesDir)
+      : [];
+    const baseToActual = new Map();
+    for (const name of exportedNames) {
+      // strip only the last extension; keep any collision suffixes as part of basename
+      const base = name.replace(/\.[^.]+$/, "");
+      baseToActual.set(base.toLowerCase(), name);
+    }
+
     const personsMap = new Map(); // slug -> {id,name}
 
     photos.forEach((p) => {
       /* derive names & filenames */
       p.originalName = path.parse(p.original_filename).name;
       const tsSegment = formatPreciseTimestamp(p.date);
-      p.exportedFilename = `${tsSegment}-${p.originalName}.jpg`;
+      const base = `${tsSegment}-${p.originalName}`;
+      // Prefer the real file if we already exported it (any extension)
+      let actual = baseToActual.get(base.toLowerCase());
+      // Cheap fallbacks for common collision suffixes if needed:
+      if (!actual) {
+        actual =
+          baseToActual.get(`${base.toLowerCase()}-1`) ||
+          baseToActual.get(`${base.toLowerCase()} (1)`);
+      }
+      // If still not found (e.g., export still running), keep the canonical guess
+      p.exportedFilename = actual || `${base}.jpg`;
 
       /* normalise persons */
       p.persons = Array.isArray(p.persons) ? p.persons : [];

--- a/backend/server.js
+++ b/backend/server.js
@@ -69,6 +69,7 @@ app.use("/images/:albumUUID/:imageName", async (req, res) => {
     if (await fs.pathExists(imagePath)) {
       res.sendFile(imagePath);
     } else {
+      console.warn(`[images] 404 ${albumUUID}/${imageName}`);
       res.status(404).send("Image not found");
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Map exported image basenames to actual filenames so API returns existing files regardless of extension or suffix
- Log missing image requests to aid debugging of 404s

## Testing
- `npm run lint:backend` *(fails: Missing script "lint" — no lint script for backend)*
- `npm run test:backend` *(fails: Cannot find module '/workspace/photo-filter/backend/node_modules/.bin/jest')*
- `npm --prefix backend install` *(fails: cannot find Foundation.framework when building osx-tag, preventing dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68af596910ac833091e79770f8382b0d