### PR TITLE
Preserve photo microseconds and add image filename fallback

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -59,21 +59,44 @@ app.set("views", path.join(__dirname, "views"));
 // Serve static files
 app.use(express.static(path.join(__dirname, "public")));
 
-// Dynamic image serving middleware
+// Dynamic image serving middleware with fuzzy fallback
 app.use("/images/:albumUUID/:imageName", async (req, res) => {
   const { albumUUID, imageName } = req.params;
   const imagesDir = path.join(__dirname, "data", "albums", albumUUID, "images");
 
   try {
-    const imagePath = path.join(imagesDir, imageName);
-    if (await fs.pathExists(imagePath)) {
-      res.sendFile(imagePath);
-    } else {
-      console.warn(`[images] 404 ${albumUUID}/${imageName}`);
-      res.status(404).send("Image not found");
+    const exact = path.join(imagesDir, imageName);
+    if (await fs.pathExists(exact)) return res.sendFile(exact);
+
+    // Fallback: ignore microseconds; match by seconds + original name (+ common collision suffixes)
+    const want = imageName.replace(/\.[^.]+$/, "").toLowerCase(); // strip extension
+    const dash = want.indexOf("-");
+    if (dash > 0) {
+      const wantSeconds = want.slice(0, dash).slice(0, 15); // YYYYMMDDTHHMMSS
+      const wantTail = want.slice(dash + 1); // "IMG_1079" / "IMG_1079-1" / "IMG_1079 (1)"
+
+      const files = await fs.readdir(imagesDir);
+      const candidate = files.find((f) => {
+        const b = f.replace(/\.[^.]+$/, "").toLowerCase();
+        const d2 = b.indexOf("-");
+        if (d2 < 0) return false;
+        const sec = b.slice(0, d2).slice(0, 15); // seconds portion
+        const tail = b.slice(d2 + 1);
+        return (
+          sec === wantSeconds &&
+          (tail === wantTail ||
+            tail.startsWith(wantTail + "-") ||
+            tail.startsWith(wantTail + " (")
+          )
+        );
+      });
+      if (candidate) return res.sendFile(path.join(imagesDir, candidate));
     }
-  } catch (error) {
-    console.error("Error serving image:", error);
+
+    console.warn(`[images] 404 ${albumUUID}/${imageName}`);
+    res.status(404).send("Image not found");
+  } catch (err) {
+    console.error("Error serving image:", err);
     res.status(500).send("Internal Server Error");
   }
 });

--- a/backend/utils/precise-timestamp.js
+++ b/backend/utils/precise-timestamp.js
@@ -35,63 +35,47 @@ import { DateTime } from "luxon";
  * @returns {string} e.g. "20250531T174503123000Z"
  */
 export function formatPreciseTimestamp(dateLike) {
-  let dt;
-
-  // 1. Already a Date object ------------------------------------------------
+  // Fast path: Date object (no microseconds beyond ms available)
   if (dateLike instanceof Date) {
-    dt = DateTime.fromJSDate(dateLike, { zone: "utc" });
-  } else if (typeof dateLike === "string") {
-    let src = dateLike.trim();
-    let tzSeconds = 0;
-    const m = src.match(/([+-]\d{2}:\d{2}):(\d{2})$/);
-    if (m) {
-      tzSeconds = Number(m[2]) * (m[1].startsWith("+") ? 1 : -1);
-      src = src.replace(/([+-]\d{2}:\d{2}):(\d{2})$/, m[1]);
-    }
-
-    // 2. ISO 8601 -----------------------------------------------------------
-    dt = DateTime.fromISO(src, { setZone: true });
-
-    // 3. SQL format  (Photos DB default)  -----------------------------------
-    if (!dt.isValid) {
-      dt = DateTime.fromSQL(src, { setZone: true });
-    }
-
-    // 4. EXIF “YYYY:MM:DD HH:MM:SS”  ----------------------------------------
-    if (!dt.isValid) {
-      dt = DateTime.fromFormat(
-        src,
-        "yyyy:MM:dd HH:mm:ss",
-        { zone: "local" } // assume local if no offset supplied
-      );
-    }
-
-    // 5. As a last resort let JS Date try -----------------------------------
-    if (!dt.isValid) {
-      const jsDate = new Date(src);
-      if (!isNaN(jsDate.getTime())) {
-        dt = DateTime.fromJSDate(jsDate, { zone: "utc" });
-      }
-    }
-    if (dt.isValid && tzSeconds) {
-      dt = dt.plus({ seconds: -tzSeconds });
-    }
-
-    // (if still invalid we fall through and raise)
-  } else {
-    throw new TypeError(
-      `formatPreciseTimestamp(): expected Date or string, got ${typeof dateLike}`
+    const dt = DateTime.fromJSDate(dateLike, { zone: "utc" });
+    const micro = String(dateLike.getUTCMilliseconds() * 1000).padStart(
+      6,
+      "0"
     );
+    return dt.toUTC().toFormat("yyyyLLdd'T'HHmmss") + micro + "Z";
   }
 
-  if (!dt.isValid) {
-    throw new Error(
-      `formatPreciseTimestamp(): invalid input (“${dateLike}” – ${dt.invalidReason})`
-    );
+  if (typeof dateLike !== "string") {
+    throw new TypeError(`formatPreciseTimestamp(): expected Date or string`);
   }
 
-  // Luxon gives millisecond precision; multiply to micro‑seconds.
-  const micro = String(dt.millisecond * 1_000).padStart(6, "0");
+  let src = dateLike.trim();
+
+  // 1) Capture fractional seconds (up to 6) before parsing to avoid Luxon rounding
+  let micro = "000000";
+  const frac = src.match(/\.(\d{1,6})/); // e.g. ".924927" or ".160000"
+  if (frac) {
+    micro = (frac[1] + "000000").slice(0, 6); // pad/truncate to 6
+    src = src.replace(/\.(\d{1,6})/, ""); // remove fraction for the parser
+  }
+
+  // 2) Support offsets with seconds, e.g. "+00:09:21"
+  let tzSeconds = 0;
+  const m = src.match(/([+-]\d{2}:\d{2}):(\d{2})$/);
+  if (m) {
+    tzSeconds = (m[1].startsWith("+") ? 1 : -1) * parseInt(m[2], 10);
+    src = src.replace(m[0], m[1]); // strip ":SS" so Luxon can parse
+  }
+
+  // 3) Parse with zone preserved
+  let dt = DateTime.fromISO(src, { setZone: true });
+  if (!dt.isValid) dt = DateTime.fromSQL(src, { setZone: true });
+  if (!dt.isValid)
+    dt = DateTime.fromFormat(src, "yyyy:MM:dd HH:mm:ss", { zone: "local" });
+  if (!dt.isValid)
+    throw new Error(`formatPreciseTimestamp(): invalid input (“${dateLike}”)`);
+
+  if (tzSeconds) dt = dt.plus({ seconds: -tzSeconds });
 
   return dt.toUTC().toFormat("yyyyLLdd'T'HHmmss") + micro + "Z";
 }


### PR DESCRIPTION
## Summary
- Preserve true microseconds when formatting photo timestamps
- Add fallback image resolver that matches on seconds + original name if exact filename missing

## Testing
- `npm test` *(fails: Cannot find module '/workspace/photo-filter/backend/node_modules/.bin/jest')*
- `node --experimental-vm-modules node_modules/.bin/jest --config backend/jest.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68afa4dea31c8330a667e9a489db47f7