### PR TITLE
Add export-all album export endpoint and UI button

### DIFF
--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -1,0 +1,76 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { fileURLToPath } from 'url';
+import { runPythonScript } from '../../utils/run-python-script.js';
+import { runOsxphotosExportImages } from '../../utils/export-images.js';
+import { formatPreciseTimestamp } from '../../utils/helpers.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function exportAll(req, res) {
+  try {
+    const albumUUID = req.params.albumUUID;
+    const { persons = [] } = req.body || {};
+
+    const dataDir = path.join(__dirname, '..', '..', 'data');
+    const albumDir = path.join(dataDir, 'albums', albumUUID);
+    const photosJSON = path.join(albumDir, 'photos.json');
+    const imagesDir = path.join(albumDir, 'images');
+    const exportBase = path.join(__dirname, '..', '..', 'exports', albumUUID);
+
+    const venvDir = path.join(__dirname, '..', '..', 'venv');
+    const python = path.join(venvDir, 'bin', 'python3');
+    const pyExport = path.join(
+      __dirname,
+      '..',
+      '..',
+      'scripts',
+      'export_photos_in_album.py'
+    );
+    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
+
+    await fs.ensureDir(imagesDir);
+    if (!(await fs.pathExists(photosJSON))) {
+      await runPythonScript(python, pyExport, [albumUUID], photosJSON);
+      await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
+    }
+
+    const photos = await fs.readJson(photosJSON);
+    photos.forEach((photo) => {
+      const originalName = path.parse(photo.original_filename).name;
+      const ts = formatPreciseTimestamp(photo.date);
+      photo.exportedFilename = `${ts}-${originalName}.jpg`;
+    });
+
+    let filtered = photos;
+    if (persons.length > 0) {
+      filtered = photos.filter((photo) => {
+        const names = Array.isArray(photo.persons) ? photo.persons : [];
+        return persons.every((name) => names.includes(name));
+      });
+    }
+
+    await fs.ensureDir(exportBase);
+    const albumAllDir = path.join(exportBase, '_all');
+    await fs.ensureDir(albumAllDir);
+
+    for (const photo of filtered) {
+      if (!photo.exportedFilename) {
+        continue;
+      }
+      const src = path.join(imagesDir, photo.exportedFilename);
+      if (await fs.pathExists(src)) {
+        const dest = path.join(albumAllDir, photo.exportedFilename);
+        await fs.copy(src, dest);
+      }
+    }
+
+    return res.json({
+      message: `Exported ${filtered.length} photos to ${albumAllDir}`,
+    });
+  } catch (err) {
+    console.error('exportAll error:', err);
+    return res.status(500).json({ errors: [{ detail: 'Internal Server Error' }] });
+  }
+}

--- a/backend/controllers/api/index.js
+++ b/backend/controllers/api/index.js
@@ -6,3 +6,4 @@ export { getPeopleInAlbum, getPhotosByPerson } from "./people-controller.js";
 export { getPeopleByFilename } from "./filename-controller.js";
 export { getTimeIndex } from "./time-controller.js";
 export { exportTopN } from "./export-top-n.js";
+export { exportAll } from "./export-all.js";

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -9,6 +9,7 @@ import {
   getAlbumById,
   getPhotosByAlbumData,
   exportTopN,
+  exportAll,
 } from "../controllers/api/index.js";
 import {
   getPeopleInAlbum,
@@ -46,9 +47,10 @@ apiRouter.get("/photos/by-filename/:filename/persons", getPeopleByFilename);
 apiRouter.get("/time-index", getTimeIndex);
 
 // ======================
-//   Export Top‑N Endpoint
+//   Export Endpoints
 // ======================
 apiRouter.post("/albums/:albumUUID/export-top-n", exportTopN);
+apiRouter.post("/albums/:albumUUID/export-all", exportAll);
 
 // ======================
 //   REFRESH Endpoint

--- a/frontend/photo-filter-frontend/app/controllers/albums/album.js
+++ b/frontend/photo-filter-frontend/app/controllers/albums/album.js
@@ -167,6 +167,23 @@ export default class AlbumsAlbumController extends Controller {
     });
   }
 
+  @action
+  async exportAll() {
+    const albumId = this.router.currentRoute.params.album_id;
+    const apiHost = config.APP.apiHost;
+    const body = {
+      persons: this.persons,
+    };
+
+    await fetch(`${apiHost}/api/albums/${albumId}/export-all`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
   updateQueryParams() {
     let currentRoute = this.router.currentRouteName;
     let albumId = this.router.currentRoute.params.album_id;

--- a/frontend/photo-filter-frontend/app/templates/albums/album.hbs
+++ b/frontend/photo-filter-frontend/app/templates/albums/album.hbs
@@ -26,6 +26,9 @@
   <button type="button" class="btn btn-xs" {{on "click" this.exportTopN}}>
     Export Top N
   </button>
+  <button type="button" class="btn btn-xs" {{on "click" this.exportAll}}>
+    Export All
+  </button>
 </div>
 
 <!-- Remove the did-update modifier -->


### PR DESCRIPTION
## Summary
- add a backend controller and route to export every photo in an album to the `_all` directory without per-attribute folders
- expose the new endpoint through the album page with a dedicated "Export All" button alongside the existing top-N export
- allow both endpoints to respect the current person filters when exporting

## Testing
- npm test *(fails: jest binary missing in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68fe974e344c8330b8143794ab90e646