### PR TITLE
Harden non-synced storage handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ backend/cache/
 .idea/
 .vscode/
 project-overview.txt
+backend/exports/
+
+# Local export roots (non-synced)
+/photo-filter-local/
+/photo-filter-exports/

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ This monorepo contains both the Ember.js frontend and the Express.js backend of 
 - **project-guidelines.md**: Collaboration and coding standards.
 - **docs/API_ENDPOINTS.md**: Reference for all available API routes.
 
+## Storage
+
+- `PF_LOCAL_ROOT`  (default: `/Users/Shared/photo-filter-local`)
+- `PF_EXPORT_ROOT` (default: `<PF_LOCAL_ROOT>/exports`)
+
+These must **not** point inside iCloud Drive (`~/Library/Mobile Documents/com~apple~CloudDocs`).
+
 ## Features
 
 - **Album Navigation**: Browse albums via a left-side navigation column.

--- a/backend/config/storage-paths.js
+++ b/backend/config/storage-paths.js
@@ -1,0 +1,66 @@
+import path from "path";
+import fs from "fs-extra";
+import os from "os";
+
+/**
+ * Return true if the realpath of `p` resolves inside iCloud Drive.
+ */
+export function isICloudPath(p) {
+  const home = os.homedir();
+  const icloudRoot = path.resolve(
+    path.join(home, "Library", "Mobile Documents", "com~apple~CloudDocs")
+  );
+
+  let real;
+  try {
+    real = fs.realpathSync.native
+      ? fs.realpathSync.native(p)
+      : fs.realpathSync(p);
+  } catch {
+    // If it doesn't exist yet, test the parent dir instead.
+    const parent = path.resolve(path.join(p, ".."));
+    real = fs.realpathSync.native
+      ? fs.realpathSync.native(parent)
+      : fs.realpathSync(parent);
+  }
+
+  const rel = path.relative(icloudRoot, real);
+  return !rel || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function resolveSafeRoot(envVar, defaultAbs) {
+  const requested = path.resolve(process.env[envVar] || defaultAbs);
+  if (isICloudPath(requested) && process.env.PF_ALLOW_ICLOUD_PATH !== "1") {
+    throw new Error(
+      `${envVar} points inside iCloud Drive; choose a local, non-synced path: ${requested}`
+    );
+  }
+  return requested;
+}
+
+// Defaults: safe local, not synced
+const DEFAULT_LOCAL_ROOT = "/Users/Shared/photo-filter-local";
+
+export function getLocalRoot() {
+  return resolveSafeRoot("PF_LOCAL_ROOT", DEFAULT_LOCAL_ROOT);
+}
+
+export function getExportRoot() {
+  // If PF_EXPORT_ROOT is not set, nest exports under local root
+  const explicit = process.env.PF_EXPORT_ROOT;
+  if (explicit) return resolveSafeRoot("PF_EXPORT_ROOT", explicit);
+  return path.join(getLocalRoot(), "exports");
+}
+
+export function getAlbumImagesDir(albumUUID) {
+  return path.join(getLocalRoot(), "albums", albumUUID, "images");
+}
+
+export function getExportBase(albumUUID) {
+  return path.join(getExportRoot(), albumUUID);
+}
+
+export async function ensureRoots() {
+  await fs.ensureDir(getLocalRoot());
+  await fs.ensureDir(getExportRoot());
+}

--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -3,6 +3,11 @@ import fs from 'fs-extra';
 import { fileURLToPath } from 'url';
 import { runPythonScript } from '../../utils/run-python-script.js';
 import { runOsxphotosExportImages } from '../../utils/export-images.js';
+import {
+  getAlbumImagesDir,
+  getExportBase,
+  ensureRoots,
+} from '../../config/storage-paths.js';
 import { formatPreciseTimestamp } from '../../utils/helpers.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -13,11 +18,14 @@ export async function exportAll(req, res) {
     const albumUUID = req.params.albumUUID;
     const { persons = [] } = req.body || {};
 
+    await ensureRoots();
     const dataDir = path.join(__dirname, '..', '..', 'data');
     const albumDir = path.join(dataDir, 'albums', albumUUID);
     const photosJSON = path.join(albumDir, 'photos.json');
-    const imagesDir = path.join(albumDir, 'images');
-    const exportBase = path.join(__dirname, '..', '..', 'exports', albumUUID);
+    const imagesDir = getAlbumImagesDir(albumUUID);
+    const exportBase = getExportBase(albumUUID);
+
+    console.log('exportAll paths:', { imagesDir, exportBase });
 
     const venvDir = path.join(__dirname, '..', '..', 'venv');
     const python = path.join(venvDir, 'bin', 'python3');
@@ -30,6 +38,7 @@ export async function exportAll(req, res) {
     );
     const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
 
+    await fs.ensureDir(albumDir);
     await fs.ensureDir(imagesDir);
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);

--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -4,6 +4,11 @@ import { fileURLToPath } from 'url';
 import { runPythonScript } from '../../utils/run-python-script.js';
 import { runOsxphotosExportImages } from '../../utils/export-images.js';
 import { formatPreciseTimestamp, getNestedProperty } from '../../utils/helpers.js';
+import {
+  getAlbumImagesDir,
+  getExportBase,
+  ensureRoots,
+} from '../../config/storage-paths.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -39,17 +44,21 @@ export async function exportTopN(req, res) {
     const { n, persons = [] } = req.body || {};
     const topN = Math.max(parseInt(n, 10) || 1, 1);
 
+    await ensureRoots();
     const dataDir = path.join(__dirname, '..', '..', 'data');
     const albumDir = path.join(dataDir, 'albums', albumUUID);
     const photosJSON = path.join(albumDir, 'photos.json');
-    const imagesDir = path.join(albumDir, 'images');
-    const exportBase = path.join(__dirname, '..', '..', 'exports', albumUUID);
+    const imagesDir = getAlbumImagesDir(albumUUID);
+    const exportBase = getExportBase(albumUUID);
+
+    console.log('exportTopN paths:', { imagesDir, exportBase });
 
     const venvDir = path.join(__dirname, '..', '..', 'venv');
     const python = path.join(venvDir, 'bin', 'python3');
     const pyExport = path.join(__dirname, '..', '..', 'scripts', 'export_photos_in_album.py');
     const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
 
+    await fs.ensureDir(albumDir);
     await fs.ensureDir(imagesDir);
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -17,6 +17,7 @@ import {
   getNestedProperty,
 } from "../../utils/helpers.js";
 import { Serializer } from "jsonapi-serializer";
+import { getAlbumImagesDir, ensureRoots } from "../../config/storage-paths.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -56,10 +57,11 @@ export const getPhotosByAlbumData = async (req, res) => {
     const sortAttr = req.query.sort || "score.overall";
     const sortOrder = req.query.order || "desc";
 
+    await ensureRoots();
     const dataDir = path.join(__dirname, "..", "..", "data");
     const albumDir = path.join(dataDir, "albums", albumUUID);
     const photosJSON = path.join(albumDir, "photos.json");
-    const imagesDir = path.join(albumDir, "images");
+    const imagesDir = getAlbumImagesDir(albumUUID);
 
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const python = path.join(venvDir, "bin", "python3");
@@ -73,6 +75,7 @@ export const getPhotosByAlbumData = async (req, res) => {
     const osxphotos = path.join(venvDir, "bin", "osxphotos");
 
     /* (1) Ensure exports exist */
+    await fs.ensureDir(albumDir);
     await fs.ensureDir(imagesDir);
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,11 @@ import exphbs from "express-handlebars";
 import routes from "./routes/index.js";
 import fs from "fs-extra";
 import cors from "cors"; // Import cors
+import {
+  ensureRoots,
+  getLocalRoot,
+  getExportRoot,
+} from "./config/storage-paths.js";
 
 const app = express();
 
@@ -15,6 +20,12 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+await ensureRoots();
+console.log("Storage roots", {
+  localRoot: getLocalRoot(),
+  exportRoot: getExportRoot(),
+});
 
 // Enable CORS for all routes
 app.use(cors());

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -46,12 +46,28 @@ export async function runOsxphotosExportImages(
   const filenameTemplate =
     "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
 
-  const cmd = `"${osxphotosPath}" export "${imagesDir}" \
-  --uuid-from-file "${uuidsFile}" \
-  --download-missing --use-photokit --ramdb \
-  --only-photos --skip-live --skip-raw \
-  --filename "${filenameTemplate}" \
-  --convert-to-jpeg --jpeg-ext jpg`;
+  const args = [
+    osxphotosPath,
+    "export",
+    imagesDir,
+    "--uuid-from-file",
+    uuidsFile,
+    "--download-missing",
+    "--use-photokit",
+    "--ramdb",
+    "--update",
+    "--only-photos",
+    "--skip-live",
+    "--skip-raw",
+    "--filename",
+    filenameTemplate,
+    "--convert-to-jpeg",
+    "--jpeg-ext",
+    "jpg",
+  ];
 
+  const cmd = args
+    .map((a) => (/(\s|\\)/.test(String(a)) ? `"${a}"` : a))
+    .join(" ");
   await execCommand(cmd, "osxphotos image export failed:");
 }

--- a/backend/utils/run-python-script.js
+++ b/backend/utils/run-python-script.js
@@ -2,6 +2,7 @@
 
 import { exec } from "child_process";
 import fs from "fs-extra";
+import path from "path";
 
 export async function runPythonScript(
   pythonPath,
@@ -26,6 +27,7 @@ export async function runPythonScript(
         }
         // Write stdout to the outputPath
         try {
+          await fs.ensureDir(path.dirname(outputPath));
           await fs.writeFile(outputPath, stdout, "utf-8");
           console.log(`Output written to ${outputPath}`);
           resolve();


### PR DESCRIPTION
## Summary
- add a storage paths helper to resolve non-synced local roots and guard against iCloud directories
- update export controllers to use the new storage helpers and log the resolved image/export destinations
- keep the fast-path osxphotos flags when exporting images and document the storage environment variables
- ensure album metadata directories exist before invoking export scripts so photos.json can be generated reliably
- harden the storage helpers and Python writer by creating output directories on write, tightening the iCloud guard, logging resolved roots at startup, and ignoring the legacy exports folder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68febe7848108330a7493538663fea87