### PR TITLE
Fix osxphotos filename template quoting

### DIFF
--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -66,8 +66,17 @@ export async function runOsxphotosExportImages(
     "jpg",
   ];
 
-  const cmd = args
-    .map((a) => (/(\s|\\)/.test(String(a)) ? `"${a}"` : a))
-    .join(" ");
+  const cmd = args.map(quoteForShell).join(" ");
   await execCommand(cmd, "osxphotos image export failed:");
+}
+
+function quoteForShell(value) {
+  const stringValue = String(value);
+
+  if (/^[A-Za-z0-9_\/:=+.,-]+$/.test(stringValue) && stringValue.length > 0) {
+    return stringValue;
+  }
+
+  const escaped = stringValue.replace(/(["$`\\])/g, "\\$1");
+  return `"${escaped}"`;
 }


### PR DESCRIPTION
## Summary
- ensure osxphotos export arguments are shell-quoted to prevent brace expansion
- add a reusable helper to escape unsafe characters when building the command string

## Testing
- npm --prefix backend run test *(fails: Cannot find module '.../.bin/jest')*

------
https://chatgpt.com/codex/tasks/task_e_68fecee2e19883308de148f3373dcf23