### PR TITLE
Align image storage paths with local root

### DIFF
--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -23,6 +23,21 @@ export async function exportAll(req, res) {
     const albumDir = path.join(dataDir, 'albums', albumUUID);
     const photosJSON = path.join(albumDir, 'photos.json');
     const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(albumDir, 'images');
+
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
+      }
+    } catch (e) {
+      console.warn('Could not create legacy images symlink:', {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
     const exportBase = getExportBase(albumUUID);
 
     console.log('exportAll paths:', { imagesDir, exportBase });

--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -49,6 +49,21 @@ export async function exportTopN(req, res) {
     const albumDir = path.join(dataDir, 'albums', albumUUID);
     const photosJSON = path.join(albumDir, 'photos.json');
     const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(albumDir, 'images');
+
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
+      }
+    } catch (e) {
+      console.warn('Could not create legacy images symlink:', {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
     const exportBase = getExportBase(albumUUID);
 
     console.log('exportTopN paths:', { imagesDir, exportBase });

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -62,6 +62,21 @@ export const getPhotosByAlbumData = async (req, res) => {
     const albumDir = path.join(dataDir, "albums", albumUUID);
     const photosJSON = path.join(albumDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(albumDir, "images");
+
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
+      }
+    } catch (e) {
+      console.warn("Could not create legacy images symlink:", {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
 
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const python = path.join(venvDir, "bin", "python3");

--- a/backend/controllers/get-photos-by-album.js
+++ b/backend/controllers/get-photos-by-album.js
@@ -13,6 +13,7 @@ import {
   getNestedProperty,
   capitalizeAttributeName,
 } from "../utils/helpers.js";
+import { getAlbumImagesDir } from "../config/storage-paths.js";
 
 const require = createRequire(import.meta.url);
 const tag = require("osx-tag");
@@ -43,7 +44,8 @@ export const getPhotosByAlbum = async (req, res) => {
     const dataDir = path.join(__dirname, "..", "data");
     const photosDir = path.join(dataDir, "albums", albumUUID);
     const photosPath = path.join(photosDir, "photos.json");
-    const imagesDir = path.join(photosDir, "images");
+    const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(photosDir, "images");
     const venvDir = path.join(__dirname, "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -56,6 +58,19 @@ export const getPhotosByAlbum = async (req, res) => {
 
     await fs.ensureDir(photosDir);
     await fs.ensureDir(imagesDir);
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
+      }
+    } catch (e) {
+      console.warn("Could not create legacy images symlink:", {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
 
     if (!(await fs.pathExists(photosPath))) {
       // Export photos metadata

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -4,6 +4,7 @@ import express from "express";
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
+import { getAlbumImagesDir } from "../config/storage-paths.js";
 import {
   getAlbumsData,
   getAlbumById,
@@ -58,7 +59,7 @@ apiRouter.post("/albums/:albumUUID/export-all", exportAll);
 apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
   try {
     const { albumUUID } = req.params;
-    const dataDir = path.join(
+    const albumDir = path.join(
       __dirname,
       "..",
       "..",
@@ -66,8 +67,9 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       "albums",
       albumUUID
     );
-    const photosPath = path.join(dataDir, "photos.json");
-    const imagesDir = path.join(dataDir, "images");
+    const photosPath = path.join(albumDir, "photos.json");
+    const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(albumDir, "images");
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -85,6 +87,9 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
     if (await fs.pathExists(imagesDir)) {
       await fs.remove(imagesDir);
     }
+    if (await fs.pathExists(legacyImagesDir)) {
+      await fs.remove(legacyImagesDir);
+    }
 
     // Re-run python script
     await runPythonScript(pythonPath, scriptPath, [albumUUID], photosPath);
@@ -94,6 +99,20 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       imagesDir,
       photosPath
     );
+
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
+      }
+    } catch (e) {
+      console.warn("Could not create legacy images symlink:", {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
 
     return res.json({
       message: `Album ${albumUUID} metadata and images have been refreshed.`,

--- a/backend/scripts/detect_cameras.js
+++ b/backend/scripts/detect_cameras.js
@@ -23,6 +23,7 @@ import fg from "fast-glob";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { getAlbumImagesDir } from "../config/storage-paths.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -68,15 +69,7 @@ async function main() {
   }
   const asJson = rest.includes("--json");
 
-  // images live under backend/data/albums/<uuid>/images/…
-  const imagesDir = path.join(
-    __dirname,
-    "..",
-    "data",
-    "albums",
-    albumUuid,
-    "images"
-  );
+  const imagesDir = getAlbumImagesDir(albumUuid);
   const patterns = ["**/*.{jpg,jpeg,JPG,JPEG,png,PNG,heic,HEIC}"];
   const imagePaths = await fg(patterns, {
     cwd: imagesDir,

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ import {
   ensureRoots,
   getLocalRoot,
   getExportRoot,
+  getAlbumImagesDir,
 } from "./config/storage-paths.js";
 
 const app = express();
@@ -70,10 +71,13 @@ app.set("views", path.join(__dirname, "views"));
 // Serve static files
 app.use(express.static(path.join(__dirname, "public")));
 
+// Back-compat: expose legacy /data/albums URLs from new local root
+app.use("/data/albums", express.static(path.join(getLocalRoot(), "albums")));
+
 // Dynamic image serving middleware with fuzzy fallback
 app.use("/images/:albumUUID/:imageName", async (req, res) => {
   const { albumUUID, imageName } = req.params;
-  const imagesDir = path.join(__dirname, "data", "albums", albumUUID, "images");
+  const imagesDir = getAlbumImagesDir(albumUUID);
 
   try {
     const exact = path.join(imagesDir, imageName);
@@ -85,6 +89,11 @@ app.use("/images/:albumUUID/:imageName", async (req, res) => {
     if (dash > 0) {
       const wantSeconds = want.slice(0, dash).slice(0, 15); // YYYYMMDDTHHMMSS
       const wantTail = want.slice(dash + 1); // "IMG_1079" / "IMG_1079-1" / "IMG_1079 (1)"
+
+      if (!(await fs.pathExists(imagesDir))) {
+        console.warn(`[images] missing dir ${albumUUID}`);
+        return res.status(404).send("Image not found");
+      }
 
       const files = await fs.readdir(imagesDir);
       const candidate = files.find((f) => {


### PR DESCRIPTION
## Summary
- create a legacy data/albums symlink in photo export controllers so existing code can read the new storage root
- update image serving middleware and refresh endpoint to use getAlbumImagesDir and expose a /data/albums static mount for compatibility
- point legacy exports and tooling at the local image root instead of backend/data/albums

## Testing
- npm --prefix backend test *(fails: backend Jest dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fed5123cdc83308b6ed8e7cb9eb770