### PR TITLE
Stream osxphotos export output and delay legacy symlink

### DIFF
--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -24,20 +24,6 @@ export async function exportAll(req, res) {
     const photosJSON = path.join(albumDir, 'photos.json');
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, 'images');
-
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
-      }
-    } catch (e) {
-      console.warn('Could not create legacy images symlink:', {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
     const exportBase = getExportBase(albumUUID);
 
     console.log('exportAll paths:', { imagesDir, exportBase });
@@ -55,6 +41,19 @@ export async function exportAll(req, res) {
 
     await fs.ensureDir(albumDir);
     await fs.ensureDir(imagesDir);
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
+      }
+    } catch (e) {
+      console.warn('Could not create legacy images symlink:', {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);
       await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);

--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -50,7 +50,17 @@ export async function exportTopN(req, res) {
     const photosJSON = path.join(albumDir, 'photos.json');
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, 'images');
+    const exportBase = getExportBase(albumUUID);
 
+    console.log('exportTopN paths:', { imagesDir, exportBase });
+
+    const venvDir = path.join(__dirname, '..', '..', 'venv');
+    const python = path.join(venvDir, 'bin', 'python3');
+    const pyExport = path.join(__dirname, '..', '..', 'scripts', 'export_photos_in_album.py');
+    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
+
+    await fs.ensureDir(albumDir);
+    await fs.ensureDir(imagesDir);
     try {
       await fs.ensureDir(path.dirname(legacyImagesDir));
       const st = await fs.lstat(legacyImagesDir).catch(() => null);
@@ -64,17 +74,6 @@ export async function exportTopN(req, res) {
         e,
       });
     }
-    const exportBase = getExportBase(albumUUID);
-
-    console.log('exportTopN paths:', { imagesDir, exportBase });
-
-    const venvDir = path.join(__dirname, '..', '..', 'venv');
-    const python = path.join(venvDir, 'bin', 'python3');
-    const pyExport = path.join(__dirname, '..', '..', 'scripts', 'export_photos_in_album.py');
-    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
-
-    await fs.ensureDir(albumDir);
-    await fs.ensureDir(imagesDir);
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);
       await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -64,20 +64,6 @@ export const getPhotosByAlbumData = async (req, res) => {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
 
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
-      }
-    } catch (e) {
-      console.warn("Could not create legacy images symlink:", {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
-
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const python = path.join(venvDir, "bin", "python3");
     const pyExport = path.join(
@@ -92,6 +78,19 @@ export const getPhotosByAlbumData = async (req, res) => {
     /* (1) Ensure exports exist */
     await fs.ensureDir(albumDir);
     await fs.ensureDir(imagesDir);
+    try {
+      await fs.ensureDir(path.dirname(legacyImagesDir));
+      const st = await fs.lstat(legacyImagesDir).catch(() => null);
+      if (!st) {
+        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
+      }
+    } catch (e) {
+      console.warn("Could not create legacy images symlink:", {
+        legacyImagesDir,
+        imagesDir,
+        e,
+      });
+    }
     if (!(await fs.pathExists(photosJSON))) {
       await runPythonScript(python, pyExport, [albumUUID], photosJSON);
       await runOsxphotosExportImages(

--- a/backend/utils/exec-command.js
+++ b/backend/utils/exec-command.js
@@ -1,32 +1,74 @@
 // ./utils/exec-command.js
 
-import { exec } from "child_process";
+import { spawn } from "child_process";
 
-// Helper function to execute shell commands
-export function execCommand(command, errorMessage) {
+/**
+ * Execute a command while streaming output to this process. Accepts either a
+ * shell command string or an array of [command, ...args].
+ *
+ * @param {string|string[]} cmdOrArgs
+ * @param {string} errorMessage
+ * @param {{cwd?: string, env?: NodeJS.ProcessEnv}} options
+ */
+export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options = {}) {
   return new Promise((resolve, reject) => {
-    console.log(`Executing command:\n${command}`);
+    let command;
+    let args = [];
+    let useShell = false;
 
-    exec(
-      command,
-      { env: process.env, maxBuffer: 1024 * 1024 * 1024 * 2 },
-      (error, stdout, stderr) => {
-        if (error) {
-          console.error(`${errorMessage}\nError: ${error.message}`);
-          if (stderr) {
-            console.error(`stderr:\n${stderr}`);
-          }
-          reject(error);
-          return;
-        }
-        if (stdout) {
-          console.log(`stdout:\n${stdout}`);
-        }
-        if (stderr) {
-          console.error(`stderr:\n${stderr}`);
-        }
-        resolve({ stdout, stderr });
+    if (Array.isArray(cmdOrArgs)) {
+      [command, ...args] = cmdOrArgs;
+    } else {
+      command = cmdOrArgs;
+      useShell = true;
+    }
+
+    const { cwd, env } = options;
+    const child = spawn(command, args, {
+      shell: useShell,
+      cwd,
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const printable = Array.isArray(cmdOrArgs)
+      ? [command, ...args].join(" ")
+      : command;
+    console.log(`Executing command:\n${printable}`);
+
+    let stderrBuf = Buffer.alloc(0);
+
+    const appendStderr = (chunk) => {
+      stderrBuf = Buffer.concat([stderrBuf, Buffer.from(chunk)]);
+      if (stderrBuf.length > 256 * 1024) {
+        stderrBuf = stderrBuf.slice(-256 * 1024);
       }
-    );
+    };
+
+    child.stdout.on("data", (data) => {
+      process.stdout.write(data);
+    });
+
+    child.stderr.on("data", (data) => {
+      process.stderr.write(data);
+      appendStderr(data);
+    });
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const tail = stderrBuf.toString("utf8").trim();
+      const message = tail ? `${errorMessage}\n${tail}` : errorMessage;
+      const error = new Error(message);
+      error.code = code;
+      error.signal = signal;
+      reject(error);
+    });
   });
 }

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -47,7 +47,6 @@ export async function runOsxphotosExportImages(
     "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
 
   const args = [
-    osxphotosPath,
     "export",
     imagesDir,
     "--uuid-from-file",
@@ -66,17 +65,5 @@ export async function runOsxphotosExportImages(
     "jpg",
   ];
 
-  const cmd = args.map(quoteForShell).join(" ");
-  await execCommand(cmd, "osxphotos image export failed:");
-}
-
-function quoteForShell(value) {
-  const stringValue = String(value);
-
-  if (/^[A-Za-z0-9_\/:=+.,-]+$/.test(stringValue) && stringValue.length > 0) {
-    return stringValue;
-  }
-
-  const escaped = stringValue.replace(/(["$`\\])/g, "\\$1");
-  return `"${escaped}"`;
+  await execCommand([osxphotosPath, ...args], "osxphotos image export failed:");
 }


### PR DESCRIPTION
## Summary
- stream `execCommand` output to avoid buffering massive osxphotos exports and keep only the recent stderr tail for diagnostics
- call osxphotos with spawn-style arguments to bypass shell quoting and reuse streaming execution
- ensure album image directories exist before attempting to create the legacy images symlink in each export controller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fee47d01348330ba6ee88f4f8cf5aa