### PR TITLE
Stream album export workflow and gate album UI on status

### DIFF
--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -1,14 +1,13 @@
-import path from 'path';
-import fs from 'fs-extra';
-import { fileURLToPath } from 'url';
-import { runPythonScript } from '../../utils/run-python-script.js';
-import { runOsxphotosExportImages } from '../../utils/export-images.js';
+import path from "path";
+import fs from "fs-extra";
+import { fileURLToPath } from "url";
 import {
   getAlbumImagesDir,
   getExportBase,
   ensureRoots,
-} from '../../config/storage-paths.js';
-import { formatPreciseTimestamp } from '../../utils/helpers.js';
+} from "../../config/storage-paths.js";
+import { formatPreciseTimestamp } from "../../utils/helpers.js";
+import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,45 +18,37 @@ export async function exportAll(req, res) {
     const { persons = [] } = req.body || {};
 
     await ensureRoots();
-    const dataDir = path.join(__dirname, '..', '..', 'data');
-    const albumDir = path.join(dataDir, 'albums', albumUUID);
-    const photosJSON = path.join(albumDir, 'photos.json');
+    const dataDir = path.join(__dirname, "..", "..", "data");
+    const albumDir = path.join(dataDir, "albums", albumUUID);
+    const photosJSON = path.join(albumDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
-    const legacyImagesDir = path.join(albumDir, 'images');
+    const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
 
-    console.log('exportAll paths:', { imagesDir, exportBase });
+    console.log("exportAll paths:", { imagesDir, exportBase });
 
-    const venvDir = path.join(__dirname, '..', '..', 'venv');
-    const python = path.join(venvDir, 'bin', 'python3');
+    const venvDir = path.join(__dirname, "..", "..", "venv");
+    const python = path.join(venvDir, "bin", "python3");
     const pyExport = path.join(
       __dirname,
-      '..',
-      '..',
-      'scripts',
-      'export_photos_in_album.py'
+      "..",
+      "..",
+      "scripts",
+      "export_photos_in_album.py",
     );
-    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
+    const osxphotos = path.join(venvDir, "bin", "osxphotos");
 
-    await fs.ensureDir(albumDir);
-    await fs.ensureDir(imagesDir);
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
-      }
-    } catch (e) {
-      console.warn('Could not create legacy images symlink:', {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
-    if (!(await fs.pathExists(photosJSON))) {
-      await runPythonScript(python, pyExport, [albumUUID], photosJSON);
-      await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
-    }
+    await ensureAlbumPrepared({
+      albumUUID,
+      albumDir,
+      photosJSON,
+      imagesDir,
+      legacyImagesDir,
+      exportBase,
+      python,
+      pyExport,
+      osxphotos,
+    });
 
     const photos = await fs.readJson(photosJSON);
     photos.forEach((photo) => {
@@ -75,7 +66,7 @@ export async function exportAll(req, res) {
     }
 
     await fs.ensureDir(exportBase);
-    const albumAllDir = path.join(exportBase, '_all');
+    const albumAllDir = path.join(exportBase, "_all");
     await fs.ensureDir(albumAllDir);
 
     for (const photo of filtered) {
@@ -93,7 +84,9 @@ export async function exportAll(req, res) {
       message: `Exported ${filtered.length} photos to ${albumAllDir}`,
     });
   } catch (err) {
-    console.error('exportAll error:', err);
-    return res.status(500).json({ errors: [{ detail: 'Internal Server Error' }] });
+    console.error("exportAll error:", err);
+    return res
+      .status(500)
+      .json({ errors: [{ detail: "Internal Server Error" }] });
   }
 }

--- a/backend/controllers/api/export-status.js
+++ b/backend/controllers/api/export-status.js
@@ -1,0 +1,25 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { ensureRoots, getExportBase } from "../../config/storage-paths.js";
+import { loadStatus } from "../../utils/export-status.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export async function getAlbumExportStatus(req, res) {
+  try {
+    const albumUUID = req.params.albumUUID;
+    await ensureRoots();
+
+    const dataDir = path.join(__dirname, "..", "..", "data");
+    const albumDir = path.join(dataDir, "albums", albumUUID);
+    const photosJSON = path.join(albumDir, "photos.json");
+    const exportBase = getExportBase(albumUUID);
+
+    const status = await loadStatus(albumUUID, { exportBase, photosJSON });
+    res.json(status);
+  } catch (err) {
+    console.error("getAlbumExportStatus error:", err);
+    res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
+  }
+}

--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -1,41 +1,43 @@
-import path from 'path';
-import fs from 'fs-extra';
-import { fileURLToPath } from 'url';
-import { runPythonScript } from '../../utils/run-python-script.js';
-import { runOsxphotosExportImages } from '../../utils/export-images.js';
-import { formatPreciseTimestamp, getNestedProperty } from '../../utils/helpers.js';
+import path from "path";
+import fs from "fs-extra";
+import { fileURLToPath } from "url";
+import {
+  formatPreciseTimestamp,
+  getNestedProperty,
+} from "../../utils/helpers.js";
 import {
   getAlbumImagesDir,
   getExportBase,
   ensureRoots,
-} from '../../config/storage-paths.js';
+} from "../../config/storage-paths.js";
+import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Aesthetic score attributes to process
 export const AESTHETIC_ATTRIBUTES = [
-  'overall',
-  'curation',
-  'highlight_visibility',
-  'behavioral',
-  'harmonious_color',
-  'immersiveness',
-  'interaction',
-  'interesting_subject',
-  'pleasant_camera_tilt',
-  'pleasant_composition',
-  'pleasant_lighting',
-  'pleasant_pattern',
-  'pleasant_perspective',
-  'pleasant_post_processing',
-  'pleasant_reflection',
-  'pleasant_symmetry',
-  'sharply_focused_subject',
-  'tastefully_blurred',
-  'well_chosen_subject',
-  'well_framed_subject',
-  'well_timed_shot',
+  "overall",
+  "curation",
+  "highlight_visibility",
+  "behavioral",
+  "harmonious_color",
+  "immersiveness",
+  "interaction",
+  "interesting_subject",
+  "pleasant_camera_tilt",
+  "pleasant_composition",
+  "pleasant_lighting",
+  "pleasant_pattern",
+  "pleasant_perspective",
+  "pleasant_post_processing",
+  "pleasant_reflection",
+  "pleasant_symmetry",
+  "sharply_focused_subject",
+  "tastefully_blurred",
+  "well_chosen_subject",
+  "well_framed_subject",
+  "well_timed_shot",
 ];
 
 export async function exportTopN(req, res) {
@@ -45,39 +47,37 @@ export async function exportTopN(req, res) {
     const topN = Math.max(parseInt(n, 10) || 1, 1);
 
     await ensureRoots();
-    const dataDir = path.join(__dirname, '..', '..', 'data');
-    const albumDir = path.join(dataDir, 'albums', albumUUID);
-    const photosJSON = path.join(albumDir, 'photos.json');
+    const dataDir = path.join(__dirname, "..", "..", "data");
+    const albumDir = path.join(dataDir, "albums", albumUUID);
+    const photosJSON = path.join(albumDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
-    const legacyImagesDir = path.join(albumDir, 'images');
+    const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
 
-    console.log('exportTopN paths:', { imagesDir, exportBase });
+    console.log("exportTopN paths:", { imagesDir, exportBase });
 
-    const venvDir = path.join(__dirname, '..', '..', 'venv');
-    const python = path.join(venvDir, 'bin', 'python3');
-    const pyExport = path.join(__dirname, '..', '..', 'scripts', 'export_photos_in_album.py');
-    const osxphotos = path.join(venvDir, 'bin', 'osxphotos');
+    const venvDir = path.join(__dirname, "..", "..", "venv");
+    const python = path.join(venvDir, "bin", "python3");
+    const pyExport = path.join(
+      __dirname,
+      "..",
+      "..",
+      "scripts",
+      "export_photos_in_album.py",
+    );
+    const osxphotos = path.join(venvDir, "bin", "osxphotos");
 
-    await fs.ensureDir(albumDir);
-    await fs.ensureDir(imagesDir);
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, 'dir');
-      }
-    } catch (e) {
-      console.warn('Could not create legacy images symlink:', {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
-    if (!(await fs.pathExists(photosJSON))) {
-      await runPythonScript(python, pyExport, [albumUUID], photosJSON);
-      await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
-    }
+    await ensureAlbumPrepared({
+      albumUUID,
+      albumDir,
+      photosJSON,
+      imagesDir,
+      legacyImagesDir,
+      exportBase,
+      python,
+      pyExport,
+      osxphotos,
+    });
 
     const photos = await fs.readJson(photosJSON);
     photos.forEach((p) => {
@@ -94,7 +94,7 @@ export async function exportTopN(req, res) {
       });
     }
 
-    const personKey = persons.length > 0 ? persons.join('_') : 'all';
+    const personKey = persons.length > 0 ? persons.join("_") : "all";
     const personDir = path.join(exportBase, personKey);
     await fs.ensureDir(personDir);
 
@@ -125,7 +125,7 @@ export async function exportTopN(req, res) {
     }
 
     // Save all unique photos for this person
-    const personAllDir = path.join(personDir, '_all');
+    const personAllDir = path.join(personDir, "_all");
     await fs.ensureDir(personAllDir);
     for (const [filename, src] of uniqueMap.entries()) {
       const dest = path.join(personAllDir, filename);
@@ -135,7 +135,7 @@ export async function exportTopN(req, res) {
     }
 
     // Maintain album-wide _all directory with uniques from every person
-    const albumAllDir = path.join(exportBase, '_all');
+    const albumAllDir = path.join(exportBase, "_all");
     await fs.ensureDir(albumAllDir);
     for (const [filename, src] of uniqueMap.entries()) {
       const dest = path.join(albumAllDir, filename);
@@ -146,7 +146,9 @@ export async function exportTopN(req, res) {
 
     return res.json({ message: `Exported top ${topN} photos to ${personDir}` });
   } catch (err) {
-    console.error('exportTopN error:', err);
-    return res.status(500).json({ errors: [{ detail: 'Internal Server Error' }] });
+    console.error("exportTopN error:", err);
+    return res
+      .status(500)
+      .json({ errors: [{ detail: "Internal Server Error" }] });
   }
 }

--- a/backend/controllers/api/index.js
+++ b/backend/controllers/api/index.js
@@ -7,3 +7,4 @@ export { getPeopleByFilename } from "./filename-controller.js";
 export { getTimeIndex } from "./time-controller.js";
 export { exportTopN } from "./export-top-n.js";
 export { exportAll } from "./export-all.js";
+export { getAlbumExportStatus } from "./export-status.js";

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -10,14 +10,17 @@
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
-import { runPythonScript } from "../../utils/run-python-script.js";
-import { runOsxphotosExportImages } from "../../utils/export-images.js";
 import {
   formatPreciseTimestamp,
   getNestedProperty,
 } from "../../utils/helpers.js";
 import { Serializer } from "jsonapi-serializer";
-import { getAlbumImagesDir, ensureRoots } from "../../config/storage-paths.js";
+import {
+  getAlbumImagesDir,
+  ensureRoots,
+  getExportBase,
+} from "../../config/storage-paths.js";
+import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,6 +66,7 @@ export const getPhotosByAlbumData = async (req, res) => {
     const photosJSON = path.join(albumDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
+    const exportBase = getExportBase(albumUUID);
 
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const python = path.join(venvDir, "bin", "python3");
@@ -71,35 +75,21 @@ export const getPhotosByAlbumData = async (req, res) => {
       "..",
       "..",
       "scripts",
-      "export_photos_in_album.py"
+      "export_photos_in_album.py",
     );
     const osxphotos = path.join(venvDir, "bin", "osxphotos");
 
-    /* (1) Ensure exports exist */
-    await fs.ensureDir(albumDir);
-    await fs.ensureDir(imagesDir);
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
-      }
-    } catch (e) {
-      console.warn("Could not create legacy images symlink:", {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
-    if (!(await fs.pathExists(photosJSON))) {
-      await runPythonScript(python, pyExport, [albumUUID], photosJSON);
-      await runOsxphotosExportImages(
-        osxphotos,
-        albumUUID,
-        imagesDir,
-        photosJSON
-      );
-    }
+    const albumStatus = await ensureAlbumPrepared({
+      albumUUID,
+      albumDir,
+      photosJSON,
+      imagesDir,
+      legacyImagesDir,
+      exportBase,
+      python,
+      pyExport,
+      osxphotos,
+    });
 
     /* (2) Load data & enrich */
     let photos = await fs.readJson(photosJSON);
@@ -175,6 +165,7 @@ export const getPhotosByAlbumData = async (req, res) => {
         sortOrder,
         scoreAttributes:
           photos.length && photos[0].score ? Object.keys(photos[0].score) : [],
+        exportStatus: albumStatus,
       },
     });
   } catch (err) {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,8 +24,8 @@
     "setup": "node ./scripts/setup.js",
     "start": "node server.js",
     "dev": "nodemon --ignore 'data/*' server.js",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest",
-    "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "generate-overview": "../generate-overview.sh",
     "postinstall": "node ./scripts/setup.js"
   }

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -4,20 +4,20 @@ import express from "express";
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
-import { getAlbumImagesDir } from "../config/storage-paths.js";
+import { getAlbumImagesDir, getExportBase } from "../config/storage-paths.js";
 import {
   getAlbumsData,
   getAlbumById,
   getPhotosByAlbumData,
   exportTopN,
   exportAll,
+  getAlbumExportStatus,
 } from "../controllers/api/index.js";
 import {
   getPeopleInAlbum,
   getPhotosByPerson,
 } from "../controllers/api/people-controller.js";
-import { runPythonScript } from "../utils/run-python-script.js";
-import { runOsxphotosExportImages } from "../utils/export-images.js";
+import { ensureAlbumPrepared } from "../utils/prepare-album.js";
 
 // === Import our new time controller
 import { getTimeIndex } from "../controllers/api/time-controller.js";
@@ -36,6 +36,7 @@ const apiRouter = express.Router();
 apiRouter.get("/albums", getAlbumsData);
 apiRouter.get("/albums/:albumUUID", getAlbumById);
 apiRouter.get("/albums/:albumUUID/photos", getPhotosByAlbumData);
+apiRouter.get("/albums/:albumUUID/status", getAlbumExportStatus);
 
 // People
 apiRouter.get("/albums/:albumUUID/persons", getPeopleInAlbum);
@@ -65,11 +66,12 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       "..",
       "data",
       "albums",
-      albumUUID
+      albumUUID,
     );
     const photosPath = path.join(albumDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
+    const exportBase = getExportBase(albumUUID);
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -77,7 +79,7 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       "..",
       "..",
       "scripts",
-      "export_photos_in_album.py"
+      "export_photos_in_album.py",
     );
     const osxphotosPath = path.join(venvDir, "bin", "osxphotos");
 
@@ -91,28 +93,17 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       await fs.remove(legacyImagesDir);
     }
 
-    // Re-run python script
-    await runPythonScript(pythonPath, scriptPath, [albumUUID], photosPath);
-    await runOsxphotosExportImages(
-      osxphotosPath,
+    await ensureAlbumPrepared({
       albumUUID,
+      albumDir,
+      photosJSON: photosPath,
       imagesDir,
-      photosPath
-    );
-
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
-      }
-    } catch (e) {
-      console.warn("Could not create legacy images symlink:", {
-        legacyImagesDir,
-        imagesDir,
-        e,
-      });
-    }
+      legacyImagesDir,
+      exportBase,
+      python: pythonPath,
+      pyExport: scriptPath,
+      osxphotos: osxphotosPath,
+    });
 
     return res.json({
       message: `Album ${albumUUID} metadata and images have been refreshed.`,

--- a/backend/utils/export-status.js
+++ b/backend/utils/export-status.js
@@ -1,0 +1,77 @@
+// backend/utils/export-status.js
+
+import fs from "fs-extra";
+import path from "path";
+
+const statusCache = new Map();
+
+function statusPath(exportBase) {
+  return path.join(exportBase, "status.json");
+}
+
+function mergeStatus(previous = {}, updates = {}) {
+  const next = { ...previous };
+  for (const [key, value] of Object.entries(updates)) {
+    if (value === undefined) continue;
+    next[key] = value;
+  }
+  return next;
+}
+
+export async function loadStatus(albumUUID, { exportBase, photosJSON }) {
+  const cached = statusCache.get(albumUUID);
+  if (cached) {
+    return cached;
+  }
+
+  let status = { status: "pending" };
+  const statusFile = statusPath(exportBase);
+
+  if (await fs.pathExists(statusFile)) {
+    try {
+      status = await fs.readJson(statusFile);
+    } catch (err) {
+      console.warn(`Failed to read status for ${albumUUID}:`, err);
+    }
+  } else if (photosJSON && (await fs.pathExists(photosJSON))) {
+    status = {
+      status: "ready",
+      finishedAt: new Date().toISOString(),
+    };
+    await writeStatus(albumUUID, exportBase, status);
+    return status;
+  }
+
+  statusCache.set(albumUUID, status);
+  return status;
+}
+
+export async function writeStatus(albumUUID, exportBase, updates) {
+  const statusFile = statusPath(exportBase);
+  await fs.ensureDir(exportBase);
+  const current =
+    statusCache.get(albumUUID) || (await readStatusFile(statusFile));
+  const next = mergeStatus(current, updates);
+  statusCache.set(albumUUID, next);
+  await fs.writeJson(statusFile, next, { spaces: 2 });
+  return next;
+}
+
+async function readStatusFile(statusFile) {
+  if (await fs.pathExists(statusFile)) {
+    try {
+      return await fs.readJson(statusFile);
+    } catch (err) {
+      console.warn(`Failed to read status file ${statusFile}:`, err);
+    }
+  }
+  return { status: "pending" };
+}
+
+export function clearStatus(albumUUID) {
+  statusCache.delete(albumUUID);
+}
+
+export function getCachedStatus(albumUUID) {
+  return statusCache.get(albumUUID);
+}

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -1,0 +1,112 @@
+// backend/utils/prepare-album.js
+
+import fs from "fs-extra";
+import path from "path";
+import { runPythonScript } from "./run-python-script.js";
+import { runOsxphotosExportImages } from "./export-images.js";
+import { loadStatus, writeStatus, clearStatus } from "./export-status.js";
+
+const inFlight = new Map();
+
+async function ensureLegacySymlink(imagesDir, legacyImagesDir) {
+  try {
+    await fs.ensureDir(path.dirname(legacyImagesDir));
+    const st = await fs.lstat(legacyImagesDir).catch(() => null);
+    if (!st) {
+      await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
+    }
+  } catch (e) {
+    console.warn("Could not create legacy images symlink:", {
+      legacyImagesDir,
+      imagesDir,
+      e,
+    });
+  }
+}
+
+async function prepareAlbumInternal(context) {
+  const {
+    albumUUID,
+    albumDir,
+    photosJSON,
+    imagesDir,
+    legacyImagesDir,
+    exportBase,
+    python,
+    pyExport,
+    osxphotos,
+  } = context;
+
+  await fs.ensureDir(albumDir);
+  await fs.ensureDir(imagesDir);
+  await ensureLegacySymlink(imagesDir, legacyImagesDir);
+
+  const status = await loadStatus(albumUUID, { exportBase, photosJSON });
+  const hasPhotos = await fs.pathExists(photosJSON);
+
+  if (hasPhotos && status.status === "ready") {
+    return status;
+  }
+
+  if (hasPhotos && status.status !== "ready") {
+    return await writeStatus(albumUUID, exportBase, {
+      status: "ready",
+      finishedAt: status.finishedAt || new Date().toISOString(),
+    });
+  }
+
+  const startedAt = new Date().toISOString();
+  const runningStatus = await writeStatus(albumUUID, exportBase, {
+    status: "running",
+    startedAt,
+    finishedAt: null,
+    errorMessage: null,
+    logPath: path.join(exportBase, "logs", `export-${albumUUID}.log`),
+  });
+
+  try {
+    const { logPath } = await runPythonScript(
+      python,
+      pyExport,
+      [albumUUID],
+      photosJSON,
+      {
+        albumUUID,
+        exportBase,
+        logPath: runningStatus.logPath,
+      },
+    );
+    await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
+    return await writeStatus(albumUUID, exportBase, {
+      status: "ready",
+      finishedAt: new Date().toISOString(),
+      errorMessage: null,
+      logPath: logPath || runningStatus.logPath,
+    });
+  } catch (err) {
+    await writeStatus(albumUUID, exportBase, {
+      status: "error",
+      finishedAt: new Date().toISOString(),
+      errorMessage: err.message,
+    });
+    throw err;
+  }
+}
+
+export function ensureAlbumPrepared(context) {
+  const { albumUUID } = context;
+  if (inFlight.has(albumUUID)) {
+    return inFlight.get(albumUUID);
+  }
+  const promise = prepareAlbumInternal(context)
+    .catch((err) => {
+      // On failure, clear cache so next attempt can retry fresh
+      clearStatus(albumUUID);
+      throw err;
+    })
+    .finally(() => {
+      inFlight.delete(albumUUID);
+    });
+  inFlight.set(albumUUID, promise);
+  return promise;
+}

--- a/backend/utils/run-python-script.js
+++ b/backend/utils/run-python-script.js
@@ -1,43 +1,152 @@
 // ./utils/run-python-script.js
 
-import { exec } from "child_process";
+import { spawn } from "child_process";
 import fs from "fs-extra";
 import path from "path";
 
+const STDERR_TAIL_MAX = 256 * 1024; // 256 KiB
+
+/**
+ * Run a Python script and stream stdout directly to `outputPath`.
+ *
+ * @param {string} pythonPath path to the Python executable
+ * @param {string} scriptPath path to the Python script
+ * @param {string[]} args arguments passed to the script
+ * @param {string} outputPath file path that will receive streamed stdout
+ * @param {{ albumUUID?: string, exportBase?: string, logPath?: string }} options
+ *   Optional metadata so we can persist logs alongside album exports.
+ */
 export async function runPythonScript(
   pythonPath,
   scriptPath,
   args = [],
-  outputPath
+  outputPath,
+  options = {},
 ) {
-  const command = `"${pythonPath}" "${scriptPath}" ${args.join(" ")}`;
-  console.log(`Executing command:\n${command}`);
+  if (!outputPath) {
+    throw new Error(
+      "runPythonScript requires an outputPath to stream stdout into",
+    );
+  }
+
+  await fs.ensureDir(path.dirname(outputPath));
+  const tmpPath = `${outputPath}.tmp`;
+
+  await fs.remove(tmpPath).catch(() => {});
+
+  const { albumUUID, exportBase, logPath: explicitLogPath } = options;
+  let logStream = null;
+  let logPath = explicitLogPath;
+
+  if (!logPath && albumUUID && exportBase) {
+    const logDir = path.join(exportBase, "logs");
+    await fs.ensureDir(logDir);
+    logPath = path.join(logDir, `export-${albumUUID}.log`);
+  }
+
+  if (logPath) {
+    await fs.ensureDir(path.dirname(logPath));
+    logStream = fs.createWriteStream(logPath, { flags: "a" });
+    logStream.write(
+      `[${new Date().toISOString()}] Running ${path.basename(scriptPath)} ${args.join(
+        " ",
+      )}\n`,
+    );
+  }
+
+  const child = spawn(pythonPath, [scriptPath, ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+    env: process.env,
+  });
+
+  console.log(
+    `Executing command:\n"${pythonPath}" "${scriptPath}"${
+      args.length ? " " + args.join(" ") : ""
+    }`,
+  );
+
+  const out = fs.createWriteStream(tmpPath, { flags: "w" });
+  child.stdout.pipe(out);
+
+  let errTail = Buffer.alloc(0);
+
+  const appendErrorTail = (chunk) => {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    errTail = errTail.length ? Buffer.concat([errTail, buf]) : Buffer.from(buf);
+    if (errTail.length > STDERR_TAIL_MAX) {
+      errTail = errTail.slice(-STDERR_TAIL_MAX);
+    }
+  };
+
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    appendErrorTail(chunk);
+    if (logStream) {
+      logStream.write(chunk);
+    }
+  });
 
   return new Promise((resolve, reject) => {
-    exec(
-      command,
-      { env: process.env, maxBuffer: 1024 * 1024 * 1024 * 2 },
-      async (error, stdout, stderr) => {
-        if (error) {
-          console.error(
-            `Error executing Python script ${scriptPath}:\n${stderr}`
-          );
-          reject(error);
-          return;
-        }
-        // Write stdout to the outputPath
-        try {
-          await fs.ensureDir(path.dirname(outputPath));
-          await fs.writeFile(outputPath, stdout, "utf-8");
-          console.log(`Output written to ${outputPath}`);
-          resolve();
-        } catch (writeError) {
-          console.error(
-            `Error writing output to ${outputPath}:\n${writeError}`
-          );
-          reject(writeError);
-        }
+    child.on("error", (error) => {
+      out.destroy();
+      fs.remove(tmpPath).catch(() => {});
+      if (logStream) {
+        logStream.write(
+          `[${new Date().toISOString()}] error: ${error.message}\n`,
+        );
+        logStream.end();
       }
-    );
+      reject(error);
+    });
+
+    child.on("close", async (code, signal) => {
+      try {
+        await new Promise((resolveClose, rejectClose) => {
+          out.end((err) => {
+            if (err) {
+              rejectClose(err);
+            } else {
+              resolveClose();
+            }
+          });
+        });
+      } catch (streamErr) {
+        if (logStream) {
+          logStream.write(
+            `[${new Date().toISOString()}] error closing stdout stream: ${streamErr.message}\n`,
+          );
+          logStream.end();
+        }
+        await fs.remove(tmpPath).catch(() => {});
+        reject(streamErr);
+        return;
+      }
+
+      if (logStream) {
+        logStream.write(
+          `[${new Date().toISOString()}] exited with code ${code}${
+            signal ? ` (signal ${signal})` : ""
+          }\n`,
+        );
+        logStream.end();
+      }
+
+      if (code === 0) {
+        try {
+          await fs.move(tmpPath, outputPath, { overwrite: true });
+          resolve({ logPath });
+        } catch (mvErr) {
+          reject(mvErr);
+        }
+        return;
+      }
+
+      await fs.remove(tmpPath).catch(() => {});
+      const tail = errTail.toString("utf8").trim();
+      const err = new Error(`Python export failed${tail ? `:\n${tail}` : ""}`);
+      err.code = code;
+      err.signal = signal;
+      reject(err);
+    });
   });
 }

--- a/frontend/photo-filter-frontend/app/controllers/albums/album.js
+++ b/frontend/photo-filter-frontend/app/controllers/albums/album.js
@@ -18,12 +18,38 @@ export default class AlbumsAlbumController extends Controller {
   // Export Top-N
   @tracked exportN = 5;
 
+  // Export status tracking
+  @tracked exportStatus = null;
+  #statusTimer = null;
+  #statusAlbumUUID = null;
+
   // Pagination
   @tracked page = 1;
   pageSize = 50;
 
+  get isExportReady() {
+    return this.exportStatus?.status === 'ready';
+  }
+
+  get isExportRunning() {
+    return this.exportStatus?.status === 'running';
+  }
+
+  get exportStatusMessage() {
+    if (!this.exportStatus) {
+      return 'Preparing album…';
+    }
+    if (this.isExportReady) {
+      return 'Album is ready.';
+    }
+    if (this.exportStatus.status === 'error') {
+      return this.exportStatus.errorMessage || 'Album export failed.';
+    }
+    return 'Preparing album…';
+  }
+
   get allPhotos() {
-    if (!this.model.isDataReady || !Array.isArray(this.model.photos)) {
+    if (!this.isExportReady || !Array.isArray(this.model.photos)) {
       return [];
     }
     return this.model.photos;
@@ -165,6 +191,7 @@ export default class AlbumsAlbumController extends Controller {
       },
       body: JSON.stringify(body),
     });
+    this.startStatusWatcher(albumId);
   }
 
   @action
@@ -182,6 +209,69 @@ export default class AlbumsAlbumController extends Controller {
       },
       body: JSON.stringify(body),
     });
+    this.startStatusWatcher(albumId);
+  }
+
+  startStatusWatcher(albumUUID) {
+    this.#statusAlbumUUID = albumUUID;
+    this.stopStatusWatcher();
+    this.exportStatus = null;
+    this.fetchStatus();
+  }
+
+  stopStatusWatcher() {
+    if (this.#statusTimer) {
+      const clearFn =
+        typeof globalThis.clearTimeout === 'function'
+          ? globalThis.clearTimeout
+          : null;
+      if (clearFn) {
+        clearFn(this.#statusTimer);
+      }
+      this.#statusTimer = null;
+    }
+  }
+
+  async fetchStatus() {
+    if (!this.#statusAlbumUUID) {
+      return;
+    }
+
+    const apiHost = config.APP.apiHost;
+    try {
+      const response = await fetch(
+        `${apiHost}/api/albums/${this.#statusAlbumUUID}/status`,
+      );
+      if (response.ok) {
+        const json = await response.json();
+        this.exportStatus = json;
+      } else {
+        this.exportStatus = {
+          status: 'error',
+          errorMessage: `Status request failed (${response.status})`,
+        };
+      }
+    } catch (error) {
+      this.exportStatus = {
+        status: 'error',
+        errorMessage: error.message,
+      };
+    }
+
+    if (!this.isExportReady && this.exportStatus?.status !== 'error') {
+      const setFn =
+        typeof globalThis.setTimeout === 'function'
+          ? globalThis.setTimeout
+          : null;
+      if (setFn) {
+        this.#statusTimer = setFn(() => this.fetchStatus(), 2000);
+      }
+    }
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.stopStatusWatcher();
   }
 
   updateQueryParams() {

--- a/frontend/photo-filter-frontend/app/routes/albums/album.js
+++ b/frontend/photo-filter-frontend/app/routes/albums/album.js
@@ -104,6 +104,13 @@ export default class AlbumsAlbumRoute extends Route {
     };
   }
 
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    if (model?.albumUUID) {
+      controller.startStatusWatcher(model.albumUUID);
+    }
+  }
+
   resetController(controller, isExiting) {
     super.resetController(...arguments);
     if (isExiting) {

--- a/frontend/photo-filter-frontend/app/templates/albums/album.hbs
+++ b/frontend/photo-filter-frontend/app/templates/albums/album.hbs
@@ -33,9 +33,24 @@
 
 <!-- Remove the did-update modifier -->
 <div>
-  <PhotoGrid
-    @photos={{this.visiblePhotos}}
-    @albumUUID={{this.model.albumUUID}}
-    @sortAttribute={{this.sort}}
-  />
+  {{#if (eq this.exportStatus.status "error")}}
+    <div class="alert alert-error shadow-lg my-8">
+      <div>
+        <span>{{this.exportStatusMessage}}</span>
+      </div>
+    </div>
+  {{else if this.isExportReady}}
+    <PhotoGrid
+      @photos={{this.visiblePhotos}}
+      @albumUUID={{this.model.albumUUID}}
+      @sortAttribute={{this.sort}}
+    />
+  {{else}}
+    <div
+      class="flex flex-col items-center gap-4 py-16 text-center text-sm text-base-content/70"
+    >
+      <span class="loading loading-spinner loading-lg text-primary"></span>
+      <span>{{this.exportStatusMessage}}</span>
+    </div>
+  {{/if}}
 </div>


### PR DESCRIPTION
## Summary
- stream album metadata exports to disk without buffering and persist bounded logs
- add shared album preparation helper with export status tracking and expose `/api/albums/:albumUUID/status`
- delay frontend photo grid rendering until exports finish and surface spinner/error messaging

## Testing
- npm --prefix backend test *(fails: backend photos controller test expects macOS storage root `/Users/Shared`)*
- npm --prefix frontend/photo-filter-frontend test *(fails: existing lint violations and Chrome launcher missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_690043552b708330b8153cfca72fa133