### PR TITLE
Fix export stream handling and consolidate logs

### DIFF
--- a/backend/utils/exec-command.js
+++ b/backend/utils/exec-command.js
@@ -8,9 +8,17 @@ import { spawn } from "child_process";
  *
  * @param {string|string[]} cmdOrArgs
  * @param {string} errorMessage
- * @param {{cwd?: string, env?: NodeJS.ProcessEnv}} options
+ * @param {{
+ *   cwd?: string,
+ *   env?: NodeJS.ProcessEnv,
+ *   logStream?: import("stream").Writable,
+ * }} options
  */
-export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options = {}) {
+export function execCommand(
+  cmdOrArgs,
+  errorMessage = "Command failed:",
+  options = {},
+) {
   return new Promise((resolve, reject) => {
     let command;
     let args = [];
@@ -23,7 +31,7 @@ export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options
       useShell = true;
     }
 
-    const { cwd, env } = options;
+    const { cwd, env, logStream } = options;
     const child = spawn(command, args, {
       shell: useShell,
       cwd,
@@ -36,6 +44,17 @@ export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options
       : command;
     console.log(`Executing command:\n${printable}`);
 
+    const logMessage = (message) => {
+      if (!logStream || logStream.destroyed || logStream.writableEnded) {
+        return;
+      }
+      logStream.write(`[${new Date().toISOString()}] ${message}\n`);
+    };
+
+    if (logStream) {
+      logMessage(`Running ${printable}`);
+    }
+
     let stderrBuf = Buffer.alloc(0);
 
     const appendStderr = (chunk) => {
@@ -47,19 +66,33 @@ export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options
 
     child.stdout.on("data", (data) => {
       process.stdout.write(data);
+      if (logStream && !logStream.destroyed && !logStream.writableEnded) {
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+        logStream.write(buf);
+      }
     });
 
     child.stderr.on("data", (data) => {
       process.stderr.write(data);
       appendStderr(data);
+      if (logStream && !logStream.destroyed && !logStream.writableEnded) {
+        const buf = Buffer.isBuffer(data) ? data : Buffer.from(data);
+        logStream.write(buf);
+      }
     });
 
     child.on("error", (err) => {
+      if (logStream) {
+        logMessage(`error: ${err.message}`);
+      }
       reject(err);
     });
 
     child.on("close", (code, signal) => {
       if (code === 0) {
+        if (logStream) {
+          logMessage(`command exited with code ${code}`);
+        }
         resolve();
         return;
       }
@@ -68,6 +101,13 @@ export function execCommand(cmdOrArgs, errorMessage = "Command failed:", options
       const error = new Error(message);
       error.code = code;
       error.signal = signal;
+      if (logStream) {
+        logMessage(
+          `command failed with code ${code}${
+            signal ? ` (signal ${signal})` : ""
+          }`,
+        );
+      }
       reject(error);
     });
   });

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -24,12 +24,14 @@ import { execCommand } from "./exec-command.js";
  * @param {string} albumUUID     Photos album UUID
  * @param {string} imagesDir     destination directory
  * @param {string} photosPath    path to the album’s photos.json
+ * @param {{ logStream?: import("stream").Writable }} [options]
  */
 export async function runOsxphotosExportImages(
   osxphotosPath,
   albumUUID,
   imagesDir,
-  photosPath
+  photosPath,
+  options = {},
 ) {
   // ------------------------------------------------------------------
   // 1 · Write the list of UUIDs that belong to this album
@@ -65,5 +67,19 @@ export async function runOsxphotosExportImages(
     "jpg",
   ];
 
-  await execCommand([osxphotosPath, ...args], "osxphotos image export failed:");
+  if (
+    options.logStream &&
+    !options.logStream.destroyed &&
+    !options.logStream.writableEnded
+  ) {
+    options.logStream.write(
+      `[${new Date().toISOString()}] Running osxphotos export for ${albumUUID}\n`,
+    );
+  }
+
+  await execCommand(
+    [osxphotosPath, ...args],
+    "osxphotos image export failed:",
+    options,
+  );
 }

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -64,7 +64,28 @@ async function prepareAlbumInternal(context) {
     logPath: path.join(exportBase, "logs", `export-${albumUUID}.log`),
   });
 
+  await fs.ensureDir(path.dirname(runningStatus.logPath));
+  const logStream = fs.createWriteStream(runningStatus.logPath, { flags: "a" });
+
+  const closeLogStream = async () => {
+    if (!logStream || logStream.destroyed || logStream.writableEnded) {
+      return;
+    }
+    await new Promise((resolve) => {
+      logStream.end(() => resolve());
+    });
+  };
+
+  const logMessage = (message) => {
+    if (!logStream || logStream.destroyed || logStream.writableEnded) {
+      return;
+    }
+    logStream.write(`[${new Date().toISOString()}] ${message}\n`);
+  };
+
   try {
+    logMessage(`Starting export for album ${albumUUID}`);
+
     const { logPath } = await runPythonScript(
       python,
       pyExport,
@@ -74,9 +95,16 @@ async function prepareAlbumInternal(context) {
         albumUUID,
         exportBase,
         logPath: runningStatus.logPath,
+        logStream,
+        appendLog: true,
       },
     );
-    await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON);
+    logMessage(`Starting osxphotos export for album ${albumUUID}`);
+
+    await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON, {
+      logStream,
+    });
+    logMessage(`Finished export for album ${albumUUID}`);
     return await writeStatus(albumUUID, exportBase, {
       status: "ready",
       finishedAt: new Date().toISOString(),
@@ -84,12 +112,18 @@ async function prepareAlbumInternal(context) {
       logPath: logPath || runningStatus.logPath,
     });
   } catch (err) {
+    logMessage(`Export failed for album ${albumUUID}: ${err.message}`);
     await writeStatus(albumUUID, exportBase, {
       status: "error",
       finishedAt: new Date().toISOString(),
       errorMessage: err.message,
+      logPath: runningStatus.logPath,
     });
+    await closeLogStream().catch(() => {});
     throw err;
+  }
+  finally {
+    await closeLogStream().catch(() => {});
   }
 }
 

--- a/backend/utils/run-python-script.js
+++ b/backend/utils/run-python-script.js
@@ -3,6 +3,7 @@
 import { spawn } from "child_process";
 import fs from "fs-extra";
 import path from "path";
+import { finished } from "stream/promises";
 
 const STDERR_TAIL_MAX = 256 * 1024; // 256 KiB
 
@@ -13,8 +14,13 @@ const STDERR_TAIL_MAX = 256 * 1024; // 256 KiB
  * @param {string} scriptPath path to the Python script
  * @param {string[]} args arguments passed to the script
  * @param {string} outputPath file path that will receive streamed stdout
- * @param {{ albumUUID?: string, exportBase?: string, logPath?: string }} options
- *   Optional metadata so we can persist logs alongside album exports.
+ * @param {{
+ *   albumUUID?: string,
+ *   exportBase?: string,
+ *   logPath?: string,
+ *   logStream?: import("stream").Writable,
+ *   appendLog?: boolean,
+ * }} options Optional metadata so we can persist logs alongside album exports.
  */
 export async function runPythonScript(
   pythonPath,
@@ -34,9 +40,17 @@ export async function runPythonScript(
 
   await fs.remove(tmpPath).catch(() => {});
 
-  const { albumUUID, exportBase, logPath: explicitLogPath } = options;
-  let logStream = null;
+  const {
+    albumUUID,
+    exportBase,
+    logPath: explicitLogPath,
+    logStream: providedLogStream,
+    appendLog = true,
+  } = options;
+
+  let logStream = providedLogStream || null;
   let logPath = explicitLogPath;
+  let ownsLogStream = false;
 
   if (!logPath && albumUUID && exportBase) {
     const logDir = path.join(exportBase, "logs");
@@ -44,29 +58,46 @@ export async function runPythonScript(
     logPath = path.join(logDir, `export-${albumUUID}.log`);
   }
 
-  if (logPath) {
+  if (!logStream && logPath) {
     await fs.ensureDir(path.dirname(logPath));
-    logStream = fs.createWriteStream(logPath, { flags: "a" });
-    logStream.write(
-      `[${new Date().toISOString()}] Running ${path.basename(scriptPath)} ${args.join(
-        " ",
-      )}\n`,
+    logStream = fs.createWriteStream(logPath, { flags: appendLog ? "a" : "w" });
+    ownsLogStream = true;
+  }
+
+  const logMessage = (message) => {
+    if (!logStream || logStream.destroyed || logStream.writableEnded) {
+      return;
+    }
+    logStream.write(`[${new Date().toISOString()}] ${message}\n`);
+  };
+
+  if (logStream) {
+    logMessage(
+      `Running ${path.basename(scriptPath)}${
+        args.length ? ` ${args.join(" ")}` : ""
+      }`,
     );
   }
 
-  const child = spawn(pythonPath, [scriptPath, ...args], {
+  const spawnArgs = ["-u", scriptPath, ...args];
+
+  const child = spawn(pythonPath, spawnArgs, {
     stdio: ["ignore", "pipe", "pipe"],
     env: process.env,
   });
 
-  console.log(
-    `Executing command:\n"${pythonPath}" "${scriptPath}"${
-      args.length ? " " + args.join(" ") : ""
-    }`,
-  );
+  const printableCommand = [pythonPath, ...spawnArgs]
+    .map((segment) => `"${segment}"`)
+    .join(" ");
+  console.log(`Executing command:\n${printableCommand}`);
 
-  const out = fs.createWriteStream(tmpPath, { flags: "w" });
-  child.stdout.pipe(out);
+  const stdoutStream = fs.createWriteStream(tmpPath, { flags: "w" });
+  child.stdout.pipe(stdoutStream);
+
+  let stdoutStreamError = null;
+  const stdoutFinished = finished(stdoutStream).catch((err) => {
+    stdoutStreamError = err;
+  });
 
   let errTail = Buffer.alloc(0);
 
@@ -81,62 +112,81 @@ export async function runPythonScript(
   child.stderr.on("data", (chunk) => {
     process.stderr.write(chunk);
     appendErrorTail(chunk);
-    if (logStream) {
-      logStream.write(chunk);
+    if (logStream && !logStream.destroyed && !logStream.writableEnded) {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      logStream.write(buf);
     }
   });
 
   return new Promise((resolve, reject) => {
-    child.on("error", (error) => {
-      out.destroy();
-      fs.remove(tmpPath).catch(() => {});
-      if (logStream) {
-        logStream.write(
-          `[${new Date().toISOString()}] error: ${error.message}\n`,
-        );
-        logStream.end();
-      }
+    let settled = false;
+    const resolveOnce = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const rejectOnce = (error) => {
+      if (settled) return;
+      settled = true;
       reject(error);
+    };
+
+    const closeOwnedLogStream = async () => {
+      if (!ownsLogStream || !logStream) {
+        return;
+      }
+      if (logStream.destroyed || logStream.writableEnded) {
+        return;
+      }
+      await new Promise((resolveClose) => {
+        logStream.end(() => resolveClose());
+      });
+    };
+
+    child.on("error", async (error) => {
+      if (!stdoutStream.destroyed) {
+        stdoutStream.destroy(error);
+      }
+      await stdoutFinished.catch(() => {});
+      await fs.remove(tmpPath).catch(() => {});
+      if (logStream) {
+        logMessage(`error: ${error.message}`);
+      }
+      await closeOwnedLogStream().catch(() => {});
+      rejectOnce(error);
     });
 
     child.on("close", async (code, signal) => {
-      try {
-        await new Promise((resolveClose, rejectClose) => {
-          out.end((err) => {
-            if (err) {
-              rejectClose(err);
-            } else {
-              resolveClose();
-            }
-          });
-        });
-      } catch (streamErr) {
+      await stdoutFinished;
+
+      if (stdoutStreamError) {
         if (logStream) {
-          logStream.write(
-            `[${new Date().toISOString()}] error closing stdout stream: ${streamErr.message}\n`,
+          logMessage(
+            `error closing stdout stream: ${stdoutStreamError.message}`,
           );
-          logStream.end();
         }
         await fs.remove(tmpPath).catch(() => {});
-        reject(streamErr);
+        await closeOwnedLogStream().catch(() => {});
+        rejectOnce(stdoutStreamError);
         return;
       }
 
       if (logStream) {
-        logStream.write(
-          `[${new Date().toISOString()}] exited with code ${code}${
+        logMessage(
+          `python exited with code ${code}${
             signal ? ` (signal ${signal})` : ""
-          }\n`,
+          }`,
         );
-        logStream.end();
       }
 
       if (code === 0) {
         try {
           await fs.move(tmpPath, outputPath, { overwrite: true });
-          resolve({ logPath });
+          await closeOwnedLogStream().catch(() => {});
+          resolveOnce({ logPath });
         } catch (mvErr) {
-          reject(mvErr);
+          await closeOwnedLogStream().catch(() => {});
+          rejectOnce(mvErr);
         }
         return;
       }
@@ -146,7 +196,8 @@ export async function runPythonScript(
       const err = new Error(`Python export failed${tail ? `:\n${tail}` : ""}`);
       err.code = code;
       err.signal = signal;
-      reject(err);
+      await closeOwnedLogStream().catch(() => {});
+      rejectOnce(err);
     });
   });
 }

--- a/frontend/photo-filter-frontend/app/controllers/albums/album.js
+++ b/frontend/photo-filter-frontend/app/controllers/albums/album.js
@@ -212,10 +212,10 @@ export default class AlbumsAlbumController extends Controller {
     this.startStatusWatcher(albumId);
   }
 
-  startStatusWatcher(albumUUID) {
+  startStatusWatcher(albumUUID, initialStatus = null) {
     this.#statusAlbumUUID = albumUUID;
     this.stopStatusWatcher();
-    this.exportStatus = null;
+    this.exportStatus = initialStatus || null;
     this.fetchStatus();
   }
 

--- a/frontend/photo-filter-frontend/app/routes/albums/album.js
+++ b/frontend/photo-filter-frontend/app/routes/albums/album.js
@@ -90,6 +90,8 @@ export default class AlbumsAlbumRoute extends Route {
     this.currentAlbum.sortOrder = order;
 
     const isDataReady = true;
+    const exportStatus = allPhotos.meta?.exportStatus || null;
+
     return {
       album,
       photos: allPhotos,
@@ -101,13 +103,14 @@ export default class AlbumsAlbumRoute extends Route {
       selectedPersons: persons,
       selectedDates: dates,
       isDataReady,
+      exportStatus,
     };
   }
 
   setupController(controller, model) {
     super.setupController(controller, model);
     if (model?.albumUUID) {
-      controller.startStatusWatcher(model.albumUUID);
+      controller.startStatusWatcher(model.albumUUID, model.exportStatus);
     }
   }
 

--- a/frontend/photo-filter-frontend/app/templates/albums/album.hbs
+++ b/frontend/photo-filter-frontend/app/templates/albums/album.hbs
@@ -38,6 +38,11 @@
       <div>
         <span>{{this.exportStatusMessage}}</span>
       </div>
+      {{#if (and this.exportStatus this.exportStatus.logPath)}}
+        <div class="text-xs opacity-70 break-all">
+          Log: {{this.exportStatus.logPath}}
+        </div>
+      {{/if}}
     </div>
   {{else if this.isExportReady}}
     <PhotoGrid
@@ -51,6 +56,11 @@
     >
       <span class="loading loading-spinner loading-lg text-primary"></span>
       <span>{{this.exportStatusMessage}}</span>
+      {{#if (and this.exportStatus this.exportStatus.logPath)}}
+        <p class="text-xs break-all text-base-content/60">
+          Log: {{this.exportStatus.logPath}}
+        </p>
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "lint:frontend": "npm --prefix frontend/photo-filter-frontend run lint",
     "generate-overview": "bash generate-overview.sh",
     "super-dev": "concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"/bin/bash -c 'npm run watch:backend'\" \"/bin/bash -c 'npm run watch:frontend'\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
+    "super-dev:lite": "concurrently -n BACKEND,FRONTEND -c cyan,green \"npm run watch:backend\" \"npm run watch:frontend\"",
+    "browserslist:update": "npx update-browserslist-db@latest",
     "watch:backend": "nodemon --watch backend --ignore backend/data --ext js,ts,hbs,sh,md --exec \"npm run start:backend\"",
     "watch:frontend": "npm --prefix frontend/photo-filter-frontend run start",
     "watch:test:backend": "npm --prefix backend run test:watch || echo 'No watch test script for backend'",


### PR DESCRIPTION
## Summary
- guard python export stdout so the destination stream is only closed once and allow callers to share a writable log stream
- plumb a single log stream through the album preparation pipeline and surface the log location in the album view while exports run
- add lite dev/browserslist scripts to reduce local noise during day-to-day work

## Testing
- npm run test:backend *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69005737f4308330a1c59384ed86424e