### PR TITLE
Write album UUID list in Python before export

### DIFF
--- a/backend/controllers/api-controller.js
+++ b/backend/controllers/api-controller.js
@@ -40,6 +40,7 @@ export const getPhotosByAlbumData = async (req, res) => {
     const photosDir = path.join(dataDir, "albums", albumUUID);
     const photosPath = path.join(photosDir, "photos.json");
     const imagesDir = path.join(photosDir, "images");
+    const uuidsFilePath = path.join(imagesDir, "uuids.txt");
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -58,13 +59,18 @@ export const getPhotosByAlbumData = async (req, res) => {
     // Check if photos.json exists
     if (!(await fs.pathExists(photosPath))) {
       // Export photos metadata
-      await runPythonScript(pythonPath, scriptPath, [albumUUID], photosPath);
+      await runPythonScript(
+        pythonPath,
+        scriptPath,
+        [albumUUID, uuidsFilePath],
+        photosPath,
+      );
       // Export images
       await runOsxphotosExportImages(
         osxphotosPath,
         albumUUID,
         imagesDir,
-        photosPath
+        uuidsFilePath
       );
 
       // After exporting, rename files to prepend the photo's capture date
@@ -126,18 +132,15 @@ async function runOsxphotosExportImages(
   osxphotosPath,
   albumUUID,
   imagesDir,
-  photosPath
+  uuidsFilePath
 ) {
-  // Read photo UUIDs from photos.json
-  const photosData = await fs.readJson(photosPath);
-  const uuids = photosData.map((photo) => photo.uuid).join("\n");
-  const uuidsFilePath = path.join(imagesDir, "uuids.txt");
-
-  // Ensure imagesDir exists
   await fs.ensureDir(imagesDir);
 
-  // Write UUIDs to uuids.txt
-  await fs.writeFile(uuidsFilePath, uuids, "utf-8");
+  if (!(await fs.pathExists(uuidsFilePath))) {
+    throw new Error(
+      `UUID list not found for album ${albumUUID} at ${uuidsFilePath}`,
+    );
+  }
 
   // Use {original_name} template to avoid double extensions
   const commandImages = `"${osxphotosPath}" export "${imagesDir}" --uuid-from-file "${uuidsFilePath}" --filename "{original_name}" --convert-to-jpeg --jpeg-ext jpg`;

--- a/backend/controllers/get-photos-by-album.js
+++ b/backend/controllers/get-photos-by-album.js
@@ -45,6 +45,7 @@ export const getPhotosByAlbum = async (req, res) => {
     const photosDir = path.join(dataDir, "albums", albumUUID);
     const photosPath = path.join(photosDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
+    const uuidsFilePath = path.join(imagesDir, "uuids.txt");
     const legacyImagesDir = path.join(photosDir, "images");
     const venvDir = path.join(__dirname, "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
@@ -74,13 +75,18 @@ export const getPhotosByAlbum = async (req, res) => {
 
     if (!(await fs.pathExists(photosPath))) {
       // Export photos metadata
-      await runPythonScript(pythonPath, scriptPath, [albumUUID], photosPath);
+      await runPythonScript(
+        pythonPath,
+        scriptPath,
+        [albumUUID, uuidsFilePath],
+        photosPath,
+      );
       // Export images with osxphotos (directly uses date/time prefix)
       await runOsxphotosExportImages(
         osxphotosPath,
         albumUUID,
         imagesDir,
-        photosPath
+        uuidsFilePath
       );
     }
 

--- a/backend/scripts/export_photos_in_album.py
+++ b/backend/scripts/export_photos_in_album.py
@@ -1,11 +1,18 @@
 # ./scripts/export_photos_in_album.py
 
-import osxphotos
-import sys
 import json
+import os
+import sys
+
+import osxphotos
 
 def main():
+    if len(sys.argv) < 2:
+        print("Usage: export_photos_in_album.py <ALBUM_UUID> [UUIDS_OUTPUT_PATH]", file=sys.stderr)
+        sys.exit(1)
+
     album_uuid = sys.argv[1]
+    uuids_output_path = sys.argv[2] if len(sys.argv) > 2 else None
     photosdb = osxphotos.PhotosDB()
     album = None
 
@@ -24,6 +31,21 @@ def main():
 
     # Convert photo objects to dictionaries
     photos_data = [photo.asdict() for photo in photos]
+
+    if uuids_output_path:
+        try:
+            directory = os.path.dirname(uuids_output_path) or "."
+            os.makedirs(directory, exist_ok=True)
+            with open(uuids_output_path, "w", encoding="utf-8") as fh:
+                for photo in photos:
+                    if getattr(photo, "uuid", None):
+                        fh.write(f"{photo.uuid}\n")
+        except OSError as exc:
+            print(
+                f"Failed to write UUIDs to {uuids_output_path}: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Output the data as JSON, handling datetime objects
     print(json.dumps(photos_data, indent=4, default=str))

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -23,28 +23,25 @@ import { execCommand } from "./exec-command.js";
  * @param {string} osxphotosPath absolute path to the `osxphotos` binary
  * @param {string} albumUUID     Photos album UUID
  * @param {string} imagesDir     destination directory
- * @param {string} photosPath    path to the album’s photos.json
+ * @param {string} uuidsFile     path to the album’s uuid list file
  * @param {{ logStream?: import("stream").Writable }} [options]
  */
 export async function runOsxphotosExportImages(
   osxphotosPath,
   albumUUID,
   imagesDir,
-  photosPath,
+  uuidsFile,
   options = {},
 ) {
-  // ------------------------------------------------------------------
-  // 1 · Write the list of UUIDs that belong to this album
-  // ------------------------------------------------------------------
-  const photos = await fs.readJson(photosPath);
-  const uuidsFile = path.join(imagesDir, "uuids.txt");
+  const resolvedUuidsFile = uuidsFile || path.join(imagesDir, "uuids.txt");
 
   await fs.ensureDir(imagesDir);
-  await fs.writeFile(uuidsFile, photos.map((p) => p.uuid).join("\n"), "utf8");
+  if (!(await fs.pathExists(resolvedUuidsFile))) {
+    throw new Error(
+      `UUID list not found for album ${albumUUID} at ${resolvedUuidsFile}`,
+    );
+  }
 
-  // ------------------------------------------------------------------
-  // 2 · Export the actual images
-  // ------------------------------------------------------------------
   const filenameTemplate =
     "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
 
@@ -52,7 +49,7 @@ export async function runOsxphotosExportImages(
     "export",
     imagesDir,
     "--uuid-from-file",
-    uuidsFile,
+    resolvedUuidsFile,
     "--download-missing",
     "--use-photokit",
     "--ramdb",

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -37,6 +37,8 @@ async function prepareAlbumInternal(context) {
     osxphotos,
   } = context;
 
+  const uuidsFile = path.join(imagesDir, "uuids.txt");
+
   await fs.ensureDir(albumDir);
   await fs.ensureDir(imagesDir);
   await ensureLegacySymlink(imagesDir, legacyImagesDir);
@@ -86,10 +88,12 @@ async function prepareAlbumInternal(context) {
   try {
     logMessage(`Starting export for album ${albumUUID}`);
 
+    await fs.remove(uuidsFile).catch(() => {});
+
     const { logPath } = await runPythonScript(
       python,
       pyExport,
-      [albumUUID],
+      [albumUUID, uuidsFile],
       photosJSON,
       {
         albumUUID,
@@ -101,9 +105,15 @@ async function prepareAlbumInternal(context) {
     );
     logMessage(`Starting osxphotos export for album ${albumUUID}`);
 
-    await runOsxphotosExportImages(osxphotos, albumUUID, imagesDir, photosJSON, {
-      logStream,
-    });
+    await runOsxphotosExportImages(
+      osxphotos,
+      albumUUID,
+      imagesDir,
+      uuidsFile,
+      {
+        logStream,
+      },
+    );
     logMessage(`Finished export for album ${albumUUID}`);
     return await writeStatus(albumUUID, exportBase, {
       status: "ready",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "generate-overview": "bash generate-overview.sh",
     "super-dev": "concurrently -n BACKEND,FRONTEND,TEST-BE,TEST-FE,OVERVIEW -c cyan,green,yellow,magenta,blue \"/bin/bash -c 'npm run watch:backend'\" \"/bin/bash -c 'npm run watch:frontend'\" \"npm run watch:test:backend\" \"npm run watch:test:frontend\" \"npm run watch:overview\"",
     "super-dev:lite": "concurrently -n BACKEND,FRONTEND -c cyan,green \"npm run watch:backend\" \"npm run watch:frontend\"",
-    "browserslist:update": "npx update-browserslist-db@latest",
+    "browserslist:update": "npx update-browserslist-db@latest --no-update-notifier",
     "watch:backend": "nodemon --watch backend --ignore backend/data --ext js,ts,hbs,sh,md --exec \"npm run start:backend\"",
     "watch:frontend": "npm --prefix frontend/photo-filter-frontend run start",
     "watch:test:backend": "npm --prefix backend run test:watch || echo 'No watch test script for backend'",


### PR DESCRIPTION
## Summary
- generate a uuids.txt sidecar from export_photos_in_album.py so large albums never flow through Node string buffers
- load that uuid list in the osxphotos export helper and legacy controllers before invoking osxphotos
- add the recommended browserslist:update convenience script with the no-update-notifier flag

## Testing
- npm run test:backend *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6900db9a9d308330ad79ed3beff4da42