### PR TITLE
Retire time index feature and remove API route

### DIFF
--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -118,6 +118,8 @@ This alignment of photography with micro-cinema underscores our commitment to br
 
 **Date:** January 12, 2025
 
+> **Status update (January 2025):** The time index feature has been retired from the application. The notes below are preserved for historical context should we revisit the idea in the future.
+
 **Overview:**
 We will implement a **time-based hierarchy** in the left nav, similar to how we list people or albums. The system will only show Year → Month → Week → Day nodes if photos exist for those nodes. Clicking them filters the photo grid accordingly.
 

--- a/TIMELINE_TAXONOMY.md
+++ b/TIMELINE_TAXONOMY.md
@@ -1,5 +1,7 @@
 # TIMELINE_TAXONOMY.md
 
+> **Status:** The time-index feature has been retired. The notes below remain for archival purposes should we decide to revive the idea.
+
 ## Purpose
 
 This document describes our upcoming feature for a time-based navigation tree in the Photo Filter Application. We aim to let the user drill into Years → Months → Weeks → Days, but **only** for nodes that actually contain photos. This dynamic approach ensures we don’t clutter the UI with empty categories.

--- a/backend/controllers/api/index.js
+++ b/backend/controllers/api/index.js
@@ -4,7 +4,6 @@ export { getAlbumsData, getAlbumById } from "./albums-controller.js";
 export { getPhotosByAlbumData } from "./photos-controller.js";
 export { getPeopleInAlbum, getPhotosByPerson } from "./people-controller.js";
 export { getPeopleByFilename } from "./filename-controller.js";
-export { getTimeIndex } from "./time-controller.js";
 export { exportTopN } from "./export-top-n.js";
 export { exportAll } from "./export-all.js";
 export { getAlbumExportStatus } from "./export-status.js";

--- a/backend/controllers/api/time-controller.js
+++ b/backend/controllers/api/time-controller.js
@@ -1,110 +1,12 @@
 // backend/controllers/api/time-controller.js
 
-import fs from "fs-extra";
-import path from "path";
-import { fileURLToPath } from "url";
-
 /**
- * getTimeIndex
- *
- * Returns a hierarchical time-based index of all photos known to the system:
- *   {
- *     "years": [
- *       {
- *         "year": 2024,
- *         "months": [
- *           {
- *             "month": 12,
- *             "days": [5, 6, 7]
- *           }
- *         ]
- *       }
- *     ]
- *   }
- *
- * Only includes years/months/days that actually have photos. Does not currently handle weeks.
+ * The time index feature has been retired. We keep this stub so that any
+ * lingering callers receive an explicit response without triggering the heavy
+ * filesystem work that previously occurred during startup.
  */
-export async function getTimeIndex(req, res) {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = path.dirname(__filename);
-
-    const dataDir = path.join(__dirname, "..", "..", "data", "albums");
-    // We'll iterate through all album folders, parse each photos.json,
-    // and accumulate date info in a structured way.
-
-    const yearMap = new Map();
-    // yearMap[year] = {
-    //   <monthNumber>: Set([dayNumbers]),
-    //   ...
-    // }
-
-    const albumDirs = await fs.readdir(dataDir, { withFileTypes: true });
-
-    for (const dirEnt of albumDirs) {
-      if (!dirEnt.isDirectory()) continue;
-      const albumUUID = dirEnt.name;
-      const photosJsonPath = path.join(dataDir, albumUUID, "photos.json");
-
-      if (!(await fs.pathExists(photosJsonPath))) {
-        continue;
-      }
-
-      const photosData = await fs.readJson(photosJsonPath);
-      for (const photo of photosData) {
-        // Date parse
-        const dateObj = new Date(photo.date);
-        if (isNaN(dateObj.getTime())) {
-          continue; // skip if invalid date
-        }
-
-        const y = dateObj.getFullYear();
-        const m = dateObj.getMonth() + 1; // 1-based
-        const d = dateObj.getDate();
-
-        if (!yearMap.has(y)) {
-          yearMap.set(y, new Map());
-        }
-        const monthMap = yearMap.get(y);
-
-        if (!monthMap.has(m)) {
-          monthMap.set(m, new Set());
-        }
-        const daySet = monthMap.get(m);
-        daySet.add(d);
-      }
-    }
-
-    // Now convert that Map-of-Maps-of-Sets into a JSON-friendly object
-    const yearsArray = [];
-    // Sort the years ascending, e.g., 2019, 2020, etc.
-    const sortedYears = Array.from(yearMap.keys()).sort((a, b) => a - b);
-
-    for (const year of sortedYears) {
-      const monthsArray = [];
-      const monthMap = yearMap.get(year);
-
-      // Sort months ascending
-      const sortedMonths = Array.from(monthMap.keys()).sort((a, b) => a - b);
-      for (const month of sortedMonths) {
-        const daysArray = Array.from(monthMap.get(month)).sort((a, b) => a - b);
-        monthsArray.push({
-          month,
-          days: daysArray,
-        });
-      }
-
-      yearsArray.push({
-        year,
-        months: monthsArray,
-      });
-    }
-
-    const finalIndex = { years: yearsArray };
-
-    return res.json(finalIndex);
-  } catch (error) {
-    console.error("Error building time index:", error);
-    return res.status(500).json({ errors: [{ detail: error.message }] });
-  }
+export async function getTimeIndex(_req, res) {
+  return res.status(410).json({
+    errors: [{ detail: "The time-index feature has been retired." }],
+  });
 }

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -19,8 +19,6 @@ import {
 } from "../controllers/api/people-controller.js";
 import { ensureAlbumPrepared } from "../utils/prepare-album.js";
 
-// === Import our new time controller
-import { getTimeIndex } from "../controllers/api/time-controller.js";
 import { getPeopleByFilename } from "../controllers/api/filename-controller.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -42,11 +40,6 @@ apiRouter.get("/albums/:albumUUID/status", getAlbumExportStatus);
 apiRouter.get("/albums/:albumUUID/persons", getPeopleInAlbum);
 apiRouter.get("/albums/:albumUUID/person/:personName", getPhotosByPerson);
 apiRouter.get("/photos/by-filename/:filename/persons", getPeopleByFilename);
-
-// ======================
-//   TIME-INDEX ENDPOINT
-// ======================
-apiRouter.get("/time-index", getTimeIndex);
 
 // ======================
 //   Export Endpoints

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -20,10 +20,10 @@ This project exposes a small JSON API for the Ember frontend. All routes are ser
 - `GET /api/photos/by-filename/:filename/persons`
   - **New.** Returns the people detected in a photo by its exported filename (e.g. `20250530T233513160000Z-_DSF7004.jpg`). Searches across all album data.
 
-## Time Index
+## Time Index (retired)
 
 - `GET /api/time-index`
-  - Hierarchical JSON of available years/months/weeks/days for the photo library.
+  - **Retired.** The backend now responds with HTTP 410 and a short error payload to signal that the feature has been removed.
 
 ## Exporting
 

--- a/frontend/photo-filter-frontend/app/components/time-nav.hbs
+++ b/frontend/photo-filter-frontend/app/components/time-nav.hbs
@@ -4,6 +4,8 @@
 
   {{#if this.isLoading}}
     <p>Loading time index...</p>
+  {{else if this.statusMessage}}
+    <p class="text-sm italic">{{this.statusMessage}}</p>
   {{else if this.timeIndex}}
     {{#if (and (eq (type-of this.timeIndex) "object") this.timeIndex.years)}}
       {{#if (is-array this.timeIndex.years)}}

--- a/frontend/photo-filter-frontend/app/components/time-nav.ts
+++ b/frontend/photo-filter-frontend/app/components/time-nav.ts
@@ -34,18 +34,32 @@ interface MonthObject {
 export default class TimeNavComponent extends Component {
   @service declare router: RouterService;
 
+  /** Whether the time index feature is enabled. */
+  private readonly timeIndexEnabled =
+    config.APP.timeIndexEnabled === true ||
+    config.APP.timeIndexEnabled === 'true';
+
   /** Raw time index data from the server. We default to null until loaded. */
   @tracked timeIndex: TimeIndexData | null = null;
 
   /** Flag to show “Loading…” while fetching data. */
   @tracked isLoading = true;
 
+  /** Optional message to surface when the feature is disabled or unavailable. */
+  @tracked statusMessage: string | null = null;
+
   /** The array of date-keys (like "2024", "2024-12", "2024-12-07") the user has selected. */
   @tracked selectedDates: string[] = [];
 
   constructor(owner: unknown, args: Record<string, unknown>) {
     super(owner, args);
-    this.loadTimeIndex();
+    if (this.timeIndexEnabled) {
+      this.loadTimeIndex();
+    } else {
+      this.statusMessage =
+        'Time-based navigation is currently disabled while the feature is retired.';
+      this.isLoading = false;
+    }
   }
 
   /**
@@ -63,6 +77,18 @@ export default class TimeNavComponent extends Component {
   async loadTimeIndex(): Promise<void> {
     try {
       const response = await fetch(`${config.APP.apiHost}/api/time-index`);
+
+      if (!response.ok) {
+        console.info(
+          'Time index request returned a non-success status:',
+          response.status,
+        );
+        this.statusMessage =
+          'Time-based navigation data is unavailable at the moment.';
+        this.timeIndex = { years: [] };
+        return;
+      }
+
       const data: unknown = await response.json();
 
       if (!data || typeof data !== 'object') {
@@ -80,6 +106,8 @@ export default class TimeNavComponent extends Component {
     } catch (err) {
       console.error('Error loading time index:', err);
       this.timeIndex = { years: [] };
+      this.statusMessage =
+        'Time-based navigation data is unavailable at the moment.';
     } finally {
       this.isLoading = false;
     }

--- a/frontend/photo-filter-frontend/config/environment.js
+++ b/frontend/photo-filter-frontend/config/environment.js
@@ -14,6 +14,7 @@ module.exports = function (environment) {
 
     APP: {
       apiHost: 'http://localhost:3000',
+      timeIndexEnabled: false,
     },
 
     // Add routerScroll configuration here

--- a/generate-overview.sh
+++ b/generate-overview.sh
@@ -161,29 +161,16 @@ echo "" >> "$OUTPUT_FILE"
 list_files "./frontend/photo-filter-frontend" "$OUTPUT_FILE"
 
 #####################################
-# 9) Attempt to fetch /api/time-index
+# 9) Time index endpoint status
 #####################################
 {
-  echo "## Time Index from /api/time-index"
+  echo "## Time Index Endpoint"
+  echo ""
+  echo "The time index feature has been retired; the backend now responds with HTTP 410."
+  echo ""
+  echo "---"
   echo ""
 } >> "$OUTPUT_FILE"
-
-if command -v curl >/dev/null 2>&1; then
-  echo "Fetching http://localhost:3000/api/time-index ..." >> "$OUTPUT_FILE"
-  echo "" >> "$OUTPUT_FILE"
-
-  # Attempt silent fetch
-  # If it fails, note that
-  if ! curl -s http://localhost:3000/api/time-index >> "$OUTPUT_FILE"; then
-    echo "Could not fetch /api/time-index. Is the server running?" >> "$OUTPUT_FILE"
-  fi
-else
-  echo "curl not found, cannot fetch /api/time-index" >> "$OUTPUT_FILE"
-fi
-
-echo "" >> "$OUTPUT_FILE"
-echo "---" >> "$OUTPUT_FILE"
-echo "" >> "$OUTPUT_FILE"
 
 #####################################
 # 10) Summaries of each photos.json


### PR DESCRIPTION
## Summary
- replace the time index controller with a 410 stub and remove the API route wiring
- gate the frontend time navigation component behind a config flag and show a retirement message when disabled
- document the feature retirement and stop the overview script from curling the removed endpoint

## Testing
- npm run lint:frontend *(fails: existing lint issues in the frontend workspace)*

------
https://chatgpt.com/codex/tasks/task_e_6901574fe878833082f76e38e6ec1196