### PR TITLE
Fix stream-json usage in filename controller

### DIFF
--- a/backend/controllers/api/filename-controller.js
+++ b/backend/controllers/api/filename-controller.js
@@ -2,8 +2,7 @@ import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
 import { createReadStream } from "node:fs";
-import { parser } from "stream-json";
-import { streamArray } from "stream-json/streamers/StreamArray.js";
+import StreamArray from "stream-json/streamers/StreamArray.js";
 import { formatPreciseTimestamp } from "../../utils/helpers.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -101,9 +100,7 @@ async function buildPeopleIndexStreaming(photosPath) {
     return index;
   }
 
-  const stream = createReadStream(photosPath)
-    .pipe(parser())
-    .pipe(streamArray());
+  const stream = createReadStream(photosPath).pipe(StreamArray.withParser());
 
   for await (const { value: photo } of stream) {
     if (!photo) continue;


### PR DESCRIPTION
## Summary
- switch the filename controller to use StreamArray.withParser()
- resolve the ESM/CommonJS interop issue with stream-json

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69037b5250408330a31028e0e3b3e1df