### PR TITLE
Stabilize albums export handoff and backend tooling

### DIFF
--- a/backend/controllers/api/albums-controller.js
+++ b/backend/controllers/api/albums-controller.js
@@ -2,12 +2,15 @@
 
 import path from "path";
 import fs from "fs-extra";
-import { fileURLToPath } from "url";
-import { runPythonScript } from "../../utils/run-python-script.js";
 import { Serializer } from "jsonapi-serializer";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import {
+  albumsPaths,
+  ensureAlbumsExported,
+  EXPORT_RETRY_AFTER_SECONDS,
+  isTransientJsonError,
+  readExportStatus,
+  readJsonWithRetry,
+} from "../../utils/albums-store.js";
 
 const PersonSerializer = new Serializer("person", {
   id: "id",
@@ -29,30 +32,60 @@ const AlbumSerializer = new Serializer("album", {
 });
 
 export const getAlbumsData = async (req, res) => {
+  let exportStatus = null;
   try {
-    const dataDir = path.join(__dirname, "..", "..", "data");
-    const albumsPath = path.join(dataDir, "albums.json");
-    const venvDir = path.join(__dirname, "..", "..", "venv");
-    const pythonPath = path.join(venvDir, "bin", "python3");
-    const scriptPath = path.join(
-      __dirname,
-      "..",
-      "..",
-      "scripts",
-      "export_albums.py"
-    );
+    await ensureAlbumsExported();
+    exportStatus = await readExportStatus();
 
-    await fs.ensureDir(dataDir);
+    const albumsData = await readJsonWithRetry(albumsPaths.albumsPath);
 
-    if (!(await fs.pathExists(albumsPath))) {
-      console.log("albums.json not found. Exporting albums using osxphotos...");
-      await runPythonScript(pythonPath, scriptPath, [], albumsPath);
+    if (exportStatus?.status) {
+      res.set("X-PF-Export-Status", exportStatus.status);
+    } else {
+      res.set("X-PF-Export-Status", "ready");
+    }
+    if (exportStatus?.startedAt) {
+      res.set("X-PF-Export-Started-At", exportStatus.startedAt);
+    }
+    if (exportStatus?.finishedAt) {
+      res.set("X-PF-Export-Finished-At", exportStatus.finishedAt);
     }
 
-    const albumsData = await fs.readJson(albumsPath);
     const jsonApiData = AlbumSerializer.serialize(albumsData);
     res.json(jsonApiData);
   } catch (error) {
+    if (!exportStatus) {
+      exportStatus = await readExportStatus().catch(() => null);
+    }
+
+    if (exportStatus?.status) {
+      res.set("X-PF-Export-Status", exportStatus.status);
+      if (exportStatus.startedAt) {
+        res.set("X-PF-Export-Started-At", exportStatus.startedAt);
+      }
+      if (exportStatus.finishedAt) {
+        res.set("X-PF-Export-Finished-At", exportStatus.finishedAt);
+      }
+    }
+
+    if (isTransientJsonError(error)) {
+      res
+        .status(503)
+        .set("Retry-After", EXPORT_RETRY_AFTER_SECONDS.toString())
+        .set("X-PF-Exporting", "1");
+      if (!res.getHeader("X-PF-Export-Status")) {
+        res.set("X-PF-Export-Status", "running");
+      }
+      res.json({
+        errors: [
+          {
+            detail: "Albums export in progress. Please retry shortly.",
+          },
+        ],
+      });
+      return;
+    }
+
     console.error("Error fetching albums:", error);
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
   }
@@ -61,12 +94,27 @@ export const getAlbumsData = async (req, res) => {
 export const getAlbumById = async (req, res) => {
   try {
     const albumUUID = req.params.albumUUID;
-    const dataDir = path.join(__dirname, "..", "..", "data");
-    const albumsPath = path.join(dataDir, "albums.json");
+    await ensureAlbumsExported();
+
+    const dataDir = albumsPaths.dataDir;
+    const albumsPath = albumsPaths.albumsPath;
     const photosDir = path.join(dataDir, "albums", albumUUID);
     const photosPath = path.join(photosDir, "photos.json");
 
-    const albumsData = await fs.readJson(albumsPath);
+    const exportStatus = await readExportStatus();
+    if (exportStatus?.status) {
+      res.set("X-PF-Export-Status", exportStatus.status);
+    } else {
+      res.set("X-PF-Export-Status", "ready");
+    }
+    if (exportStatus?.startedAt) {
+      res.set("X-PF-Export-Started-At", exportStatus.startedAt);
+    }
+    if (exportStatus?.finishedAt) {
+      res.set("X-PF-Export-Finished-At", exportStatus.finishedAt);
+    }
+
+    const albumsData = await readJsonWithRetry(albumsPath);
     const album = albumsData.find((a) => a.uuid === albumUUID);
 
     if (!album) {
@@ -111,6 +159,22 @@ export const getAlbumById = async (req, res) => {
 
     res.json(merged);
   } catch (error) {
+    if (isTransientJsonError(error)) {
+      res
+        .status(503)
+        .set("Retry-After", EXPORT_RETRY_AFTER_SECONDS.toString())
+        .set("X-PF-Exporting", "1")
+        .set("X-PF-Export-Status", "running")
+        .json({
+          errors: [
+            {
+              detail: "Albums export in progress. Please retry shortly.",
+            },
+          ],
+        });
+      return;
+    }
+
     console.error("Error fetching album:", error);
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
   }

--- a/backend/controllers/get-albums.js
+++ b/backend/controllers/get-albums.js
@@ -1,44 +1,30 @@
 // ./controllers/get-albums.js
 
-import path from "path";
-import { fileURLToPath } from "url";
-import fs from "fs-extra";
-import { runPythonScript } from "../utils/run-python-script.js";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import {
+  albumsPaths,
+  ensureAlbumsExported,
+  EXPORT_RETRY_AFTER_SECONDS,
+  isTransientJsonError,
+  readJsonWithRetry,
+} from "../utils/albums-store.js";
 
 // Function to get the list of albums
 export const getAlbums = async (req, res) => {
   try {
-    const dataDir = path.join(__dirname, "..", "data");
-    const albumsPath = path.join(dataDir, "albums.json");
-    const venvDir = path.join(__dirname, "..", "venv");
-    const pythonPath = path.join(venvDir, "bin", "python3");
-    const scriptPath = path.join(
-      __dirname,
-      "..",
-      "scripts",
-      "export_albums.py"
-    );
-
-    // Ensure data directory exists
-    await fs.ensureDir(dataDir);
-
-    // Check if albums.json exists
-    if (!(await fs.pathExists(albumsPath))) {
-      console.log("albums.json not found. Exporting albums using osxphotos...");
-
-      // Export albums using the Python script
-      await runPythonScript(pythonPath, scriptPath, [], albumsPath);
-    }
-
-    // Read albums data
-    const albumsData = await fs.readJson(albumsPath);
+    await ensureAlbumsExported();
+    const albumsData = await readJsonWithRetry(albumsPaths.albumsPath);
 
     // Render albums view
     res.render("albums", { albums: albumsData });
   } catch (error) {
+    if (isTransientJsonError(error)) {
+      res
+        .status(503)
+        .set("Retry-After", EXPORT_RETRY_AFTER_SECONDS.toString())
+        .send("Albums export in progress. Please retry shortly.");
+      return;
+    }
+
     console.error("Error fetching albums:", error);
     res.status(500).send("Internal Server Error");
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,8 +27,8 @@
     "setup": "node ./scripts/setup.js",
     "start": "node server.js",
     "dev": "nodemon --delay 500ms --watch ./ --ignore './data/**' --ignore '../frontend/**/tmp/**' --ignore '../frontend/**/dist/**' --ignore '../**/photo-filter-local/**' --ext js,mjs,cjs,json,hbs --exec \"node server.js\"",
-    "test": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --config jest.config.js",
-    "test:watch": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --config jest.config.js --watch",
+    "test": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --config jest.config.js || node --experimental-vm-modules --no-warnings ../node_modules/jest/bin/jest.js --config jest.config.js",
+    "test:watch": "node --experimental-vm-modules --no-warnings ./node_modules/jest/bin/jest.js --config jest.config.js --watch || node --experimental-vm-modules --no-warnings ../node_modules/jest/bin/jest.js --config jest.config.js --watch",
     "generate-overview": "../generate-overview.sh",
     "postinstall": "node ./scripts/setup.js",
     "smoke:people-by-filename": "bash ./scripts/smoke-people-by-filename.sh"

--- a/backend/scripts/export_albums.py
+++ b/backend/scripts/export_albums.py
@@ -1,23 +1,102 @@
 # backend/scripts/export_albums.py
 
-import osxphotos
+from __future__ import annotations
+
+import argparse
 import json
+import os
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
-def main():
-    photosdb = osxphotos.PhotosDB()
-    albums = photosdb.album_info  # Use album_info to get AlbumInfo objects
+import osxphotos
 
-    albums_data = []
-    for album in albums:
-        album_info = {
-            "uuid": album.uuid,
-            "title": album.title,
-        }
-        albums_data.append(album_info)
 
-    # Output JSON data to stdout
-    json.dump(albums_data, sys.stdout, indent=4)
+def atomic_write_json(path: Path, payload: Any) -> None:
+    """Write ``payload`` to ``path`` atomically."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_suffix = f"{path.suffix}.tmp" if path.suffix else ".tmp"
+    tmp_path = path.with_suffix(tmp_suffix)
+
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+    os.replace(tmp_path, path)
+
+
+def write_status(path: Path, status: dict[str, Any]) -> None:
+    """Persist exporter status information atomically."""
+    atomic_write_json(path, status)
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def export_albums(output_path: Path, status_path: Path | None) -> None:
+    if status_path is not None:
+        write_status(status_path, {"status": "running", "startedAt": iso_now()})
+
+    try:
+        photosdb = osxphotos.PhotosDB()
+        albums = photosdb.album_info
+
+        albums_data = []
+        for album in albums:
+            albums_data.append({
+                "uuid": album.uuid,
+                "title": album.title,
+            })
+
+        atomic_write_json(output_path, albums_data)
+
+        if status_path is not None:
+            write_status(
+                status_path,
+                {
+                    "status": "ready",
+                    "finishedAt": iso_now(),
+                    "albumsCount": len(albums_data),
+                },
+            )
+    except Exception as exc:  # pragma: no cover - surfaced to caller
+        if status_path is not None:
+            write_status(
+                status_path,
+                {
+                    "status": "error",
+                    "finishedAt": iso_now(),
+                    "message": str(exc),
+                },
+            )
+        raise
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export Photo albums to JSON")
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Destination path for albums.json",
+    )
+    parser.add_argument(
+        "--status",
+        required=False,
+        help="Optional path for export-status.json",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = parse_args(argv or sys.argv[1:])
+    output_path = Path(args.output).expanduser().resolve()
+    status_path = Path(args.status).expanduser().resolve() if args.status else None
+
+    export_albums(output_path, status_path)
+
 
 if __name__ == "__main__":
     main()

--- a/backend/utils/albums-store.js
+++ b/backend/utils/albums-store.js
@@ -1,0 +1,98 @@
+// ./utils/albums-store.js
+
+import path from "path";
+import fs from "fs-extra";
+import { fileURLToPath } from "url";
+
+import { runPythonScript } from "./run-python-script.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DATA_DIR = path.join(__dirname, "..", "data");
+const ALBUMS_PATH = path.join(DATA_DIR, "albums.json");
+const STATUS_PATH = path.join(DATA_DIR, "export-status.json");
+const VENV_DIR = path.join(__dirname, "..", "venv");
+const PYTHON_PATH = path.join(VENV_DIR, "bin", "python3");
+const SCRIPT_PATH = path.join(__dirname, "..", "scripts", "export_albums.py");
+
+export const EXPORT_RETRY_AFTER_SECONDS = 1;
+
+export const albumsPaths = {
+  dataDir: DATA_DIR,
+  albumsPath: ALBUMS_PATH,
+  statusPath: STATUS_PATH,
+};
+
+let exportInFlight = null;
+
+async function runAlbumsExporter() {
+  await fs.ensureDir(DATA_DIR);
+  console.log("Exporting albums using osxphotos...");
+  await runPythonScript(
+    PYTHON_PATH,
+    SCRIPT_PATH,
+    ["--output", ALBUMS_PATH, "--status", STATUS_PATH],
+    undefined,
+    { streamStdout: false },
+  );
+  console.log("Albums export complete.");
+}
+
+export async function ensureAlbumsExported() {
+  await fs.ensureDir(DATA_DIR);
+
+  if (await fs.pathExists(ALBUMS_PATH)) {
+    return;
+  }
+
+  if (!exportInFlight) {
+    exportInFlight = runAlbumsExporter().finally(() => {
+      exportInFlight = null;
+    });
+  }
+
+  await exportInFlight;
+}
+
+export function isTransientJsonError(error) {
+  return (
+    error?.code === "ENOENT" ||
+    error instanceof SyntaxError ||
+    error?.name === "SyntaxError"
+  );
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function readJsonWithRetry(file, options = {}) {
+  const { retries = 5, delayMs = 200 } = options;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const text = await fs.readFile(file, "utf8");
+      return JSON.parse(text);
+    } catch (error) {
+      if (!isTransientJsonError(error) || attempt === retries) {
+        throw error;
+      }
+      await delay(delayMs);
+    }
+  }
+
+  throw new Error(`Unable to read stable JSON from ${file}`);
+}
+
+export async function readExportStatus() {
+  try {
+    const text = await fs.readFile(STATUS_PATH, "utf8");
+    return JSON.parse(text);
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/backend/utils/run-python-script.js
+++ b/backend/utils/run-python-script.js
@@ -8,18 +8,20 @@ import { finished } from "stream/promises";
 const STDERR_TAIL_MAX = 256 * 1024; // 256 KiB
 
 /**
- * Run a Python script and stream stdout directly to `outputPath`.
+ * Run a Python script and optionally stream stdout directly to `outputPath`.
  *
  * @param {string} pythonPath path to the Python executable
  * @param {string} scriptPath path to the Python script
  * @param {string[]} args arguments passed to the script
- * @param {string} outputPath file path that will receive streamed stdout
+ * @param {string} outputPath file path that will receive streamed stdout.
+ *   Required when `options.streamStdout !== false`.
  * @param {{
  *   albumUUID?: string,
  *   exportBase?: string,
  *   logPath?: string,
  *   logStream?: import("stream").Writable,
  *   appendLog?: boolean,
+ *   streamStdout?: boolean,
  * }} options Optional metadata so we can persist logs alongside album exports.
  */
 export async function runPythonScript(
@@ -29,24 +31,27 @@ export async function runPythonScript(
   outputPath,
   options = {},
 ) {
-  if (!outputPath) {
-    throw new Error(
-      "runPythonScript requires an outputPath to stream stdout into",
-    );
-  }
-
-  await fs.ensureDir(path.dirname(outputPath));
-  const tmpPath = `${outputPath}.tmp`;
-
-  await fs.remove(tmpPath).catch(() => {});
-
   const {
     albumUUID,
     exportBase,
     logPath: explicitLogPath,
     logStream: providedLogStream,
     appendLog = true,
+    streamStdout = true,
   } = options;
+
+  if (streamStdout && !outputPath) {
+    throw new Error(
+      "runPythonScript requires an outputPath when streamStdout is enabled",
+    );
+  }
+
+  let tmpPath = null;
+  if (streamStdout) {
+    await fs.ensureDir(path.dirname(outputPath));
+    tmpPath = `${outputPath}.tmp`;
+    await fs.remove(tmpPath).catch(() => {});
+  }
 
   let logStream = providedLogStream || null;
   let logPath = explicitLogPath;
@@ -91,13 +96,27 @@ export async function runPythonScript(
     .join(" ");
   console.log(`Executing command:\n${printableCommand}`);
 
-  const stdoutStream = fs.createWriteStream(tmpPath, { flags: "w" });
-  child.stdout.pipe(stdoutStream);
-
+  let stdoutStream = null;
   let stdoutStreamError = null;
-  const stdoutFinished = finished(stdoutStream).catch((err) => {
-    stdoutStreamError = err;
-  });
+  let stdoutFinished = Promise.resolve();
+
+  if (streamStdout && tmpPath) {
+    stdoutStream = fs.createWriteStream(tmpPath, { flags: "w" });
+    child.stdout.pipe(stdoutStream);
+    stdoutFinished = finished(stdoutStream).catch((err) => {
+      stdoutStreamError = err;
+    });
+  } else {
+    child.stdout.on("data", (chunk) => {
+      if (chunk && chunk.length) {
+        process.stdout.write(chunk);
+        if (logStream && !logStream.destroyed && !logStream.writableEnded) {
+          const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          logStream.write(buf);
+        }
+      }
+    });
+  }
 
   let errTail = Buffer.alloc(0);
 
@@ -144,11 +163,13 @@ export async function runPythonScript(
     };
 
     child.on("error", async (error) => {
-      if (!stdoutStream.destroyed) {
+      if (stdoutStream && !stdoutStream.destroyed) {
         stdoutStream.destroy(error);
       }
       await stdoutFinished.catch(() => {});
-      await fs.remove(tmpPath).catch(() => {});
+      if (tmpPath) {
+        await fs.remove(tmpPath).catch(() => {});
+      }
       if (logStream) {
         logMessage(`error: ${error.message}`);
       }
@@ -165,7 +186,9 @@ export async function runPythonScript(
             `error closing stdout stream: ${stdoutStreamError.message}`,
           );
         }
-        await fs.remove(tmpPath).catch(() => {});
+        if (tmpPath) {
+          await fs.remove(tmpPath).catch(() => {});
+        }
         await closeOwnedLogStream().catch(() => {});
         rejectOnce(stdoutStreamError);
         return;
@@ -181,17 +204,24 @@ export async function runPythonScript(
 
       if (code === 0) {
         try {
-          await fs.move(tmpPath, outputPath, { overwrite: true });
+          if (tmpPath) {
+            await fs.move(tmpPath, outputPath, { overwrite: true });
+          }
           await closeOwnedLogStream().catch(() => {});
           resolveOnce({ logPath });
         } catch (mvErr) {
+          if (tmpPath) {
+            await fs.remove(tmpPath).catch(() => {});
+          }
           await closeOwnedLogStream().catch(() => {});
           rejectOnce(mvErr);
         }
         return;
       }
 
-      await fs.remove(tmpPath).catch(() => {});
+      if (tmpPath) {
+        await fs.remove(tmpPath).catch(() => {});
+      }
       const tail = errTail.toString("utf8").trim();
       const err = new Error(`Python export failed${tail ? `:\n${tail}` : ""}`);
       err.code = code;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "watch:test:backend": "npm --prefix backend run test:watch || echo 'No watch test script for backend'",
     "watch:test:frontend": "npm --prefix frontend/photo-filter-frontend run test:ember -- --server",
     "watch:overview": "nodemon --delay 2000ms --watch backend --watch frontend/photo-filter-frontend/app --ext js,ts,hbs,md --ignore project-overview.txt --ignore '**/dist/**' --ignore '**/tmp/**' --ignore '**/node_modules/**' --exec \"npm run generate-overview\"",
-    "dev:be": "concurrently -n BACKEND,TEST-BE -c cyan,yellow \"npm run watch:backend\" \"npm run watch:test:backend\"",
+    "dev:be": "npm run watch:backend",
+    "dev:be:with-tests": "concurrently -n BACKEND,TEST-BE -c cyan,yellow \"npm run watch:backend\" \"npm run watch:test:backend\"",
     "dev:ui": "npm --prefix frontend/photo-filter-frontend run start",
     "dev:tests": "npm --prefix frontend/photo-filter-frontend run test:ember -- --server"
   },


### PR DESCRIPTION
## Summary
- write albums export via atomic temp file handoff and emit export status metadata
- add a shared albums-store utility with single-flight exports and retry-aware readers used by the API and view controllers
- relax backend dev scripts to tolerate hoisted Jest while keeping watch mode opt-in for super-dev

## Testing
- python3 -m py_compile backend/scripts/export_albums.py
- npm --prefix backend test -- --runTestsByPath *(fails: Jest dependency not installed in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_6906d1d0afe48330a2ef96362ae30dff