### PR TITLE
Guard osxphotos exports when album UUID list is empty

### DIFF
--- a/backend/controllers/api-controller.js
+++ b/backend/controllers/api-controller.js
@@ -4,7 +4,10 @@ import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
 import { runPythonScript } from "../../utils/run-python-script.js";
-import { execCommand } from "../../utils/exec-command.js";
+import {
+  loadUuidsFromFile,
+  runOsxphotosExportImages,
+} from "../../utils/export-images.js";
 import { Serializer } from "jsonapi-serializer";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -41,6 +44,7 @@ export const getPhotosByAlbumData = async (req, res) => {
     const photosPath = path.join(photosDir, "photos.json");
     const imagesDir = path.join(photosDir, "images");
     const uuidsFilePath = path.join(imagesDir, "uuids.txt");
+    const skippedMarkerPath = path.join(imagesDir, ".skipped-empty");
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -56,6 +60,8 @@ export const getPhotosByAlbumData = async (req, res) => {
     await fs.ensureDir(photosDir);
     await fs.ensureDir(imagesDir);
 
+    let exportStatus = null;
+
     // Check if photos.json exists
     if (!(await fs.pathExists(photosPath))) {
       // Export photos metadata
@@ -65,13 +71,21 @@ export const getPhotosByAlbumData = async (req, res) => {
         [albumUUID, uuidsFilePath],
         photosPath,
       );
-      // Export images
-      await runOsxphotosExportImages(
-        osxphotosPath,
-        albumUUID,
-        imagesDir,
-        uuidsFilePath
-      );
+      const uuids = await loadUuidsFromFile(uuidsFilePath);
+      if (uuids.length === 0) {
+        await fs.ensureFile(skippedMarkerPath);
+        exportStatus = "skipped-empty";
+      } else {
+        const result = await runOsxphotosExportImages(
+          osxphotosPath,
+          albumUUID,
+          imagesDir,
+          uuidsFilePath,
+        );
+        if (result?.skippedReason === "empty-album") {
+          exportStatus = "skipped-empty";
+        }
+      }
 
       // After exporting, rename files to prepend the photo's capture date
       await renameExportedImages(imagesDir, photosPath);
@@ -79,6 +93,20 @@ export const getPhotosByAlbumData = async (req, res) => {
 
     // Read photos data
     const photosData = await fs.readJson(photosPath);
+    const albumCount = Array.isArray(photosData) ? photosData.length : 0;
+
+    if (
+      !exportStatus &&
+      albumCount === 0 &&
+      (await fs.pathExists(skippedMarkerPath))
+    ) {
+      exportStatus = "skipped-empty";
+    }
+
+    res.set("X-PF-Album-Count", String(albumCount));
+    if (exportStatus) {
+      res.set("X-PF-Export-Status", exportStatus);
+    }
 
     // Add 'originalName' property to each photo
     photosData.forEach((photo) => {
@@ -86,7 +114,10 @@ export const getPhotosByAlbumData = async (req, res) => {
     });
 
     // Extract the list of score attributes
-    const scoreAttributes = Object.keys(photosData[0].score);
+    const scoreAttributes =
+      photosData.length > 0 && photosData[0].score
+        ? Object.keys(photosData[0].score)
+        : [];
 
     // Sort photos based on the requested attribute
     photosData.sort((a, b) => {
@@ -126,28 +157,6 @@ export const getPhotosByAlbumData = async (req, res) => {
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
   }
 };
-
-// Helper function to export images using osxphotos
-async function runOsxphotosExportImages(
-  osxphotosPath,
-  albumUUID,
-  imagesDir,
-  uuidsFilePath
-) {
-  await fs.ensureDir(imagesDir);
-
-  if (!(await fs.pathExists(uuidsFilePath))) {
-    throw new Error(
-      `UUID list not found for album ${albumUUID} at ${uuidsFilePath}`,
-    );
-  }
-
-  // Use {original_name} template to avoid double extensions
-  const commandImages = `"${osxphotosPath}" export "${imagesDir}" --uuid-from-file "${uuidsFilePath}" --filename "{original_name}" --convert-to-jpeg --jpeg-ext jpg`;
-
-  console.log(`Executing command:\n${commandImages}`);
-  await execCommand(commandImages, "Error exporting album images:");
-}
 
 // Rename exported images with date-based filenames
 async function renameExportedImages(imagesDir, photosPath) {

--- a/backend/controllers/get-photos-by-album.js
+++ b/backend/controllers/get-photos-by-album.js
@@ -4,7 +4,10 @@ import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs-extra";
 import { runPythonScript } from "../utils/run-python-script.js";
-import { runOsxphotosExportImages } from "../utils/export-images.js";
+import {
+  loadUuidsFromFile,
+  runOsxphotosExportImages,
+} from "../utils/export-images.js";
 import plist from "plist";
 import { exec } from "child_process";
 import os from "os";
@@ -62,6 +65,7 @@ export const getPhotosByAlbum = async (req, res) => {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const uuidsFilePath = path.join(imagesDir, "uuids.txt");
     const legacyImagesDir = path.join(photosDir, "images");
+    const skippedMarkerPath = path.join(imagesDir, ".skipped-empty");
     const venvDir = path.join(__dirname, "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -88,6 +92,8 @@ export const getPhotosByAlbum = async (req, res) => {
       });
     }
 
+    let exportStatus = null;
+
     if (!(await fs.pathExists(photosPath))) {
       // Export photos metadata
       await runPythonScript(
@@ -96,16 +102,40 @@ export const getPhotosByAlbum = async (req, res) => {
         [albumUUID, uuidsFilePath],
         photosPath,
       );
-      // Export images with osxphotos (directly uses date/time prefix)
-      await runOsxphotosExportImages(
-        osxphotosPath,
-        albumUUID,
-        imagesDir,
-        uuidsFilePath
-      );
+      const uuids = await loadUuidsFromFile(uuidsFilePath);
+      if (uuids.length === 0) {
+        await fs.ensureFile(skippedMarkerPath);
+        exportStatus = "skipped-empty";
+      } else {
+        const result = await runOsxphotosExportImages(
+          osxphotosPath,
+          albumUUID,
+          imagesDir,
+          uuidsFilePath,
+        );
+        if (result?.skippedReason === "empty-album") {
+          exportStatus = "skipped-empty";
+        }
+      }
+    } else if (await fs.pathExists(skippedMarkerPath)) {
+      exportStatus = "skipped-empty";
     }
 
     const photosData = await fs.readJson(photosPath);
+    const albumCount = Array.isArray(photosData) ? photosData.length : 0;
+
+    if (
+      !exportStatus &&
+      albumCount === 0 &&
+      (await fs.pathExists(skippedMarkerPath))
+    ) {
+      exportStatus = "skipped-empty";
+    }
+
+    res.set("X-PF-Album-Count", String(albumCount));
+    if (exportStatus) {
+      res.set("X-PF-Export-Status", exportStatus);
+    }
 
     // Add 'original_name' property
     photosData.forEach((photo) => {
@@ -167,7 +197,10 @@ export const getPhotosByAlbum = async (req, res) => {
       photo.tags = photoTags[photo.uuid] || [];
     });
 
-    const scoreAttributes = Object.keys(photosData[0].score);
+    const scoreAttributes =
+      photosData.length > 0 && photosData[0].score
+        ? Object.keys(photosData[0].score)
+        : [];
 
     // Sort the photos by requested attribute
     photosData.sort((a, b) => {

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -17,6 +17,17 @@ import fs from "fs-extra";
 import path from "path";
 import { execCommand } from "./exec-command.js";
 
+export async function loadUuidsFromFile(filePath) {
+  const raw = await fs.readFile(filePath, "utf8").catch(() => "");
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 /**
  * Export JPEGs for the given album.
  *
@@ -41,6 +52,35 @@ export async function runOsxphotosExportImages(
       `UUID list not found for album ${albumUUID} at ${resolvedUuidsFile}`,
     );
   }
+
+  const uuids = await loadUuidsFromFile(resolvedUuidsFile);
+  const markerPath = path.join(imagesDir, ".skipped-empty");
+
+  const logMessage = (message) => {
+    if (
+      options.logStream &&
+      !options.logStream.destroyed &&
+      !options.logStream.writableEnded
+    ) {
+      options.logStream.write(
+        `[${new Date().toISOString()}] ${message}\n`,
+      );
+    }
+  };
+
+  if (uuids.length === 0) {
+    const message = `[export-images] ${albumUUID}: empty album; skipping osxphotos export`;
+    console.log(message);
+    logMessage(message);
+    await fs.ensureFile(markerPath);
+    return {
+      exported: 0,
+      skippedReason: "empty-album",
+      uuidsCount: 0,
+    };
+  }
+
+  await fs.remove(markerPath).catch(() => {});
 
   const filenameTemplate =
     "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
@@ -79,4 +119,10 @@ export async function runOsxphotosExportImages(
     "osxphotos image export failed:",
     options,
   );
+
+  return {
+    exported: uuids.length,
+    skippedReason: null,
+    uuidsCount: uuids.length,
+  };
 }

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -3,7 +3,10 @@
 import fs from "fs-extra";
 import path from "path";
 import { runPythonScript } from "./run-python-script.js";
-import { runOsxphotosExportImages } from "./export-images.js";
+import {
+  loadUuidsFromFile,
+  runOsxphotosExportImages,
+} from "./export-images.js";
 import { loadStatus, writeStatus, clearStatus } from "./export-status.js";
 import { ensureLegacySymlink } from "./symlinks.js";
 
@@ -88,18 +91,30 @@ async function prepareAlbumInternal(context) {
         appendLog: true,
       },
     );
-    logMessage(`Starting osxphotos export for album ${albumUUID}`);
-
-    await runOsxphotosExportImages(
-      osxphotos,
-      albumUUID,
-      imagesDir,
-      uuidsFile,
-      {
-        logStream,
-      },
-    );
-    logMessage(`Finished export for album ${albumUUID}`);
+    const uuids = await loadUuidsFromFile(uuidsFile);
+    let exportResult = null;
+    if (uuids.length === 0) {
+      const message = `Album ${albumUUID} empty; skipping osxphotos export`;
+      logMessage(message);
+      console.log(`[prepare-album] ${message}`);
+      await fs.ensureFile(path.join(imagesDir, ".skipped-empty"));
+    } else {
+      logMessage(`Starting osxphotos export for album ${albumUUID}`);
+      exportResult = await runOsxphotosExportImages(
+        osxphotos,
+        albumUUID,
+        imagesDir,
+        uuidsFile,
+        {
+          logStream,
+        },
+      );
+      if (exportResult?.skippedReason === "empty-album") {
+        logMessage(`Album ${albumUUID} empty; skipping osxphotos export`);
+      } else {
+        logMessage(`Finished export for album ${albumUUID}`);
+      }
+    }
     return await writeStatus(albumUUID, exportBase, {
       status: "ready",
       finishedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- add a UUID loader helper and short-circuit osxphotos when albums have no items, writing a skipped marker
- teach the album preparation flow and controllers to honor the marker, avoid spawning exports, and surface skip headers/counts
- handle empty album metadata safely when rendering or serializing responses

## Testing
- npm test *(fails: jest is not installed in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_6907664867588330ac53d0b2da91537b