### PR TITLE
Align library exports, concurrency, and resolver headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,13 @@ PF_LOCAL_ROOT=/Users/Shared/photo-filter-local
 # Exported images will default to "${PF_LOCAL_ROOT}/exports" if unset.
 PF_EXPORT_ROOT=/Users/Shared/photo-filter-local/exports
 
+# Shared JPEG library root and directory template used by osxphotos exports.
+PF_LIBRARY_ROOT=/Users/Shared/photo-filter-local/library
+PF_LIBRARY_DIR_TEMPLATE={created.utc.strftime,%Y/%m/%d}
+
+# Maximum concurrent clone/link/copy operations when preparing albums.
+PF_CLONE_CONCURRENCY=8
+
 # Allow pointing the storage roots inside iCloud Drive (0 disables, 1 enables).
 PF_ALLOW_ICLOUD_PATH=0
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@
 #DEFAULT_LOCAL_ROOT=/Users/Shared/photo-filter-local
 #PF_LOCAL_ROOT=/Users/yourname/photo-filter-local
 #PF_EXPORT_ROOT=/Users/yourname/photo-filter-exports
+#PF_LIBRARY_ROOT=/Volumes/Photos/photo-filter-library
+#PF_LIBRARY_DIR_TEMPLATE={created.utc.strftime,%Y/%m/%d}
+#PF_CLONE_CONCURRENCY=8
 
 # Customize the generated filenames for exports
 #FILENAME_TEMPLATE={created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}{ext}

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,7 +28,7 @@ Notes:
 
 - Query variant supported: `GET /api/people/by-filename?filename=...`.
 - Filenames must be percent-encoded in the URL; Express decodes automatically.
-- Responses report `X-PF-Resolve: cache|disk|json|miss|invalid` for debugging and to surface cache hits.
+- Responses report `X-PF-Resolve: cache|disk|json|miss|invalid|error` for debugging and to surface cache hits. When the photo cannot be located the API also emits `X-PF-Miss-Reason` (`cache`, `disk`, `json`, or `uninitialized`).
 - Lookups stream `<album>/photos.json` to rebuild filenames and merge Apple Photos person fields (no ML scene labels) when exported images are missing.
 - Cache TTLs and sizes can be tuned with `PF_FILENAME_CACHE_TTL_MS`, `PF_FILENAME_CACHE_MAX`, `PF_PERSONS_CACHE_TTL_MS`, and `PF_PERSONS_CACHE_MAX`.
 - Legacy compatibility: `/api/photos/by-filename/:filename/persons` continues to resolve to the same controller.
@@ -38,3 +38,11 @@ Example:
 ```bash
 backend/scripts/smoke-people-by-filename.sh "20100208T174405000000Z-005_3A.jpg"
 ```
+
+## Storage environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PF_LIBRARY_ROOT` | `<PF_LOCAL_ROOT>/library` | Override the shared library location (must point to a local, non-iCloud volume). |
+| `PF_LIBRARY_DIR_TEMPLATE` | `{created.utc.strftime,%Y/%m/%d}` | Directory layout passed to `osxphotos --directory` and used when resolving library paths. |
+| `PF_CLONE_CONCURRENCY` | `8` | Maximum concurrent clone/link/copy operations when materialising album images from the library. |

--- a/backend/config/storage-paths.js
+++ b/backend/config/storage-paths.js
@@ -2,6 +2,7 @@ import "./load-env.js";
 import path from "path";
 import fs from "fs-extra";
 import os from "os";
+import { libraryRelativePath } from "../utils/exported-filename.js";
 
 /**
  * Return true if the realpath of `p` resolves inside iCloud Drive.
@@ -44,6 +45,8 @@ const DEFAULT_LOCAL_ROOT = process.env.DEFAULT_LOCAL_ROOT
   ? path.resolve(process.env.DEFAULT_LOCAL_ROOT)
   : "/Users/Shared/photo-filter-local";
 
+export const LIBRARY_DIR_TEMPLATE_DEFAULT = "{created.utc.strftime,%Y/%m/%d}";
+
 export function getLocalRoot() {
   return resolveSafeRoot("PF_LOCAL_ROOT", DEFAULT_LOCAL_ROOT);
 }
@@ -61,6 +64,28 @@ export function getAlbumImagesDir(albumUUID) {
 
 export function getExportBase(albumUUID) {
   return path.join(getExportRoot(), albumUUID);
+}
+
+export function getLibraryRoot() {
+  const explicit = process.env.PF_LIBRARY_ROOT;
+  if (explicit) return resolveSafeRoot("PF_LIBRARY_ROOT", explicit);
+  return path.join(getLocalRoot(), "library");
+}
+
+export function getLibraryDirTemplate() {
+  const raw = process.env.PF_LIBRARY_DIR_TEMPLATE;
+  if (!raw) return LIBRARY_DIR_TEMPLATE_DEFAULT;
+  const trimmed = raw.trim();
+  return trimmed || LIBRARY_DIR_TEMPLATE_DEFAULT;
+}
+
+export function getLibraryPathForExportedName(exportedName) {
+  if (!exportedName) return null;
+  const relative = libraryRelativePath(exportedName, getLibraryDirTemplate());
+  if (relative) {
+    return path.join(getLibraryRoot(), relative, exportedName);
+  }
+  return path.join(getLibraryRoot(), exportedName);
 }
 
 async function ensureWritable(dir, label) {
@@ -81,4 +106,5 @@ async function ensureWritable(dir, label) {
 export async function ensureRoots() {
   await ensureWritable(getLocalRoot(), "localRoot");
   await ensureWritable(getExportRoot(), "exportRoot");
+  await ensureWritable(getLibraryRoot(), "libraryRoot");
 }

--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -5,8 +5,9 @@ import {
   getAlbumImagesDir,
   getExportBase,
   ensureRoots,
+  getLibraryRoot,
 } from "../../config/storage-paths.js";
-import { formatPreciseTimestamp } from "../../utils/helpers.js";
+import { buildExportedFilename } from "../../utils/exported-filename.js";
 import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -24,6 +25,7 @@ export async function exportAll(req, res) {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
 
     console.log("exportAll paths:", { imagesDir, exportBase });
 
@@ -45,6 +47,7 @@ export async function exportAll(req, res) {
       imagesDir,
       legacyImagesDir,
       exportBase,
+      libraryRoot,
       python,
       pyExport,
       osxphotos,
@@ -52,9 +55,7 @@ export async function exportAll(req, res) {
 
     const photos = await fs.readJson(photosJSON);
     photos.forEach((photo) => {
-      const originalName = path.parse(photo.original_filename).name;
-      const ts = formatPreciseTimestamp(photo.date);
-      photo.exportedFilename = `${ts}-${originalName}.jpg`;
+      photo.exportedFilename = buildExportedFilename(photo);
     });
 
     let filtered = photos;

--- a/backend/controllers/api/export-top-n.js
+++ b/backend/controllers/api/export-top-n.js
@@ -1,16 +1,15 @@
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
-import {
-  formatPreciseTimestamp,
-  getNestedProperty,
-} from "../../utils/helpers.js";
+import { getNestedProperty } from "../../utils/helpers.js";
 import {
   getAlbumImagesDir,
   getExportBase,
   ensureRoots,
+  getLibraryRoot,
 } from "../../config/storage-paths.js";
 import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
+import { buildExportedFilename } from "../../utils/exported-filename.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -53,6 +52,7 @@ export async function exportTopN(req, res) {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
 
     console.log("exportTopN paths:", { imagesDir, exportBase });
 
@@ -74,6 +74,7 @@ export async function exportTopN(req, res) {
       imagesDir,
       legacyImagesDir,
       exportBase,
+      libraryRoot,
       python,
       pyExport,
       osxphotos,
@@ -82,8 +83,7 @@ export async function exportTopN(req, res) {
     const photos = await fs.readJson(photosJSON);
     photos.forEach((p) => {
       p.originalName = path.parse(p.original_filename).name;
-      const ts = formatPreciseTimestamp(p.date);
-      p.exportedFilename = `${ts}-${p.originalName}.jpg`;
+      p.exportedFilename = buildExportedFilename(p);
     });
 
     let filtered = photos;

--- a/backend/controllers/api/filename-controller.js
+++ b/backend/controllers/api/filename-controller.js
@@ -3,7 +3,12 @@ import fs from "fs-extra";
 import { fileURLToPath } from "url";
 import { createReadStream } from "node:fs";
 import StreamArray from "stream-json/streamers/StreamArray.js";
-import { formatPreciseTimestamp } from "../../utils/helpers.js";
+import {
+  getAlbumImagesDir,
+  getLocalRoot,
+  getLibraryPathForExportedName,
+} from "../../config/storage-paths.js";
+import { buildExportedFilename } from "../../utils/exported-filename.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +53,7 @@ const RESOLVE_SOURCES = {
   JSON: "json",
   MISS: "miss",
   INVALID: "invalid",
+  ERROR: "error",
 };
 
 function readEnvInt(name, fallback) {
@@ -83,17 +89,21 @@ export async function getPeopleByFilename(req, res) {
 
     const cachedMiss = getCachedMiss(filename);
     if (cachedMiss) {
-      res.set("X-PF-Resolve", cachedMiss);
+      res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
+      if (cachedMiss.reason) {
+        res.set("X-PF-Miss-Reason", cachedMiss.reason);
+      }
       return res
         .status(404)
         .json({ errors: [{ detail: "Photo not found" }] });
     }
 
-    const dataDir = path.join(__dirname, "..", "..", "data");
-    const albumsDir = path.join(dataDir, "albums");
+    const albumsDir = path.join(getLocalRoot(), "albums");
 
     if (!(await fs.pathExists(albumsDir))) {
-      res.set("X-PF-Resolve", RESOLVE_SOURCES.JSON);
+      cacheMiss(filename, "uninitialized");
+      res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
+      res.set("X-PF-Miss-Reason", "uninitialized");
       return res
         .status(404)
         .json({ errors: [{ detail: "Photo not found" }] });
@@ -103,15 +113,18 @@ export async function getPeopleByFilename(req, res) {
     let resolveSource = albumUUID ? RESOLVE_SOURCES.CACHE : null;
     if (!albumUUID) {
       const lookupResult = await findAlbumUUIDByFilename(albumsDir, filename);
-      if (!lookupResult) {
-        cacheMiss(filename);
-        res.set("X-PF-Resolve", RESOLVE_SOURCES.JSON);
+      if (!lookupResult?.match) {
+        cacheMiss(filename, lookupResult?.missReason ?? RESOLVE_SOURCES.JSON);
+        res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
+        if (lookupResult?.missReason) {
+          res.set("X-PF-Miss-Reason", lookupResult.missReason);
+        }
         return res
           .status(404)
           .json({ errors: [{ detail: "Photo not found" }] });
       }
-      albumUUID = lookupResult.uuid;
-      resolveSource = lookupResult.source;
+      albumUUID = lookupResult.match.uuid;
+      resolveSource = lookupResult.match.source;
       cacheAlbumUUID(filename, albumUUID);
     }
 
@@ -129,7 +142,9 @@ export async function getPeopleByFilename(req, res) {
         return { persons: inLockCached, source: RESOLVE_SOURCES.CACHE };
       }
 
-      const result = await findPersonsByFilenameStreaming(photosPath, filename);
+      const result = await findPersonsByFilenameStreaming(photosPath, filename, {
+        preferDisk: resolveSource === RESOLVE_SOURCES.DISK,
+      });
       if (result.persons !== null) {
         cachePersons(cacheKey, result.persons);
       }
@@ -137,8 +152,9 @@ export async function getPeopleByFilename(req, res) {
     });
 
     if (persons === null) {
-      cacheMiss(filename);
-      res.set("X-PF-Resolve", source ?? resolveSource ?? RESOLVE_SOURCES.JSON);
+      cacheMiss(filename, RESOLVE_SOURCES.JSON);
+      res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
+      res.set("X-PF-Miss-Reason", RESOLVE_SOURCES.JSON);
       return res.status(404).json({ errors: [{ detail: "Photo not found" }] });
     }
 
@@ -147,7 +163,7 @@ export async function getPeopleByFilename(req, res) {
     return res.json({ data: persons });
   } catch (error) {
     console.error("Error looking up persons by filename:", error);
-    res.set("X-PF-Resolve", RESOLVE_SOURCES.JSON);
+    res.set("X-PF-Resolve", RESOLVE_SOURCES.ERROR);
     return res
       .status(500)
       .json({ errors: [{ detail: "Internal Server Error" }] });
@@ -234,12 +250,13 @@ function getCachedMiss(name) {
     MISS_CACHE.delete(name);
     return null;
   }
-  return entry.source;
+  return entry;
 }
 
-function cacheMiss(name, source = RESOLVE_SOURCES.MISS) {
+function cacheMiss(name, reason = RESOLVE_SOURCES.MISS) {
   MISS_CACHE.set(name, {
-    source,
+    source: RESOLVE_SOURCES.MISS,
+    reason,
     expiresAt: Date.now() + MISS_CACHE_TTL_MS,
   });
   if (MISS_CACHE.size > MISS_CACHE_MAX) {
@@ -269,12 +286,18 @@ async function runWithAlbumLock(albumUUID, fn) {
 async function findAlbumUUIDByFilename(albumsDir, filename) {
   const entries = await fs.readdir(albumsDir, { withFileTypes: true });
   const directories = entries.filter((entry) => entry.isDirectory());
+  const libraryCandidate = getLibraryPathForExportedName(filename);
+  const libraryExists = libraryCandidate
+    ? await fs.pathExists(libraryCandidate)
+    : false;
+  let missReason = RESOLVE_SOURCES.DISK;
 
   for (let i = 0; i < directories.length; i += DISK_PROBE_CONCURRENCY) {
     const batch = directories.slice(i, i + DISK_PROBE_CONCURRENCY);
     const results = await Promise.all(
       batch.map(async (entry) => {
-        const candidate = path.join(albumsDir, entry.name, "images", filename);
+        const imagesDir = getAlbumImagesDir(entry.name);
+        const candidate = path.join(imagesDir, filename);
         if (await fs.pathExists(candidate)) {
           return entry.name;
         }
@@ -283,7 +306,7 @@ async function findAlbumUUIDByFilename(albumsDir, filename) {
     );
     const match = results.find((value) => value !== null);
     if (match) {
-      return { uuid: match, source: RESOLVE_SOURCES.DISK };
+      return { match: { uuid: match, source: RESOLVE_SOURCES.DISK } };
     }
   }
 
@@ -292,13 +315,17 @@ async function findAlbumUUIDByFilename(albumsDir, filename) {
     if (!(await fs.pathExists(photosPath))) {
       continue;
     }
+    missReason = RESOLVE_SOURCES.JSON;
     const stream = createReadStream(photosPath).pipe(StreamArray.withParser());
     try {
       for await (const { value: photo } of stream) {
         if (!photo) continue;
-        const exported = buildExportedName(photo);
+        const exported = buildExportedFilename(photo);
         if (exported && exported === filename) {
-          return { uuid: entry.name, source: RESOLVE_SOURCES.JSON };
+          const source = libraryExists
+            ? RESOLVE_SOURCES.DISK
+            : RESOLVE_SOURCES.JSON;
+          return { match: { uuid: entry.name, source } };
         }
       }
     } catch (error) {
@@ -310,23 +337,30 @@ async function findAlbumUUIDByFilename(albumsDir, filename) {
     }
   }
 
-  return null;
+  const missDetails = libraryExists ? RESOLVE_SOURCES.JSON : missReason;
+  return { match: null, missReason: missDetails };
 }
 
-async function findPersonsByFilenameStreaming(photosPath, targetFilename) {
+async function findPersonsByFilenameStreaming(
+  photosPath,
+  targetFilename,
+  { preferDisk = false } = {},
+) {
   if (!(await fs.pathExists(photosPath))) {
-    return { persons: null, source: RESOLVE_SOURCES.JSON };
+    const source = preferDisk ? RESOLVE_SOURCES.DISK : RESOLVE_SOURCES.JSON;
+    return { persons: null, source };
   }
 
   const stream = createReadStream(photosPath).pipe(StreamArray.withParser());
   try {
     for await (const { value: photo } of stream) {
       if (!photo) continue;
-      const exported = buildExportedName(photo);
+      const exported = buildExportedFilename(photo);
       if (!exported || exported !== targetFilename) {
         continue;
       }
-      return { persons: extractPersons(photo), source: RESOLVE_SOURCES.JSON };
+      const source = preferDisk ? RESOLVE_SOURCES.DISK : RESOLVE_SOURCES.JSON;
+      return { persons: extractPersons(photo), source };
     }
   } catch (error) {
     throw error;
@@ -336,22 +370,8 @@ async function findPersonsByFilenameStreaming(photosPath, targetFilename) {
     }
   }
 
-  return { persons: null, source: RESOLVE_SOURCES.JSON };
-}
-
-function buildExportedName(photo) {
-  try {
-    const originalSource = photo.original_filename || photo.originalFilename;
-    if (!originalSource) return null;
-    const originalName = path.parse(originalSource).name;
-    if (!originalName) return null;
-    const rawDate = photo.date ?? photo.creation_date ?? photo.creationDate;
-    if (!rawDate) return null;
-    const timestamp = formatPreciseTimestamp(rawDate);
-    return `${timestamp}-${originalName}.jpg`;
-  } catch (err) {
-    return null;
-  }
+  const source = preferDisk ? RESOLVE_SOURCES.DISK : RESOLVE_SOURCES.JSON;
+  return { persons: null, source };
 }
 
 function extractPersons(photo) {

--- a/backend/controllers/api/index.js
+++ b/backend/controllers/api/index.js
@@ -1,7 +1,10 @@
 // ./controllers/api/index.js
 
 export { getAlbumsData, getAlbumById } from "./albums-controller.js";
-export { getPhotosByAlbumData } from "./photos-controller.js";
+export {
+  getPhotosByAlbumData,
+  prepareAlbumForExport,
+} from "./photos-controller.js";
 export { getPeopleInAlbum, getPhotosByPerson } from "./people-controller.js";
 export { getPeopleByFilename } from "./filename-controller.js";
 export { exportTopN } from "./export-top-n.js";

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -19,8 +19,11 @@ import {
   getAlbumImagesDir,
   ensureRoots,
   getExportBase,
+  getLibraryRoot,
 } from "../../config/storage-paths.js";
 import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
+import { loadStatus } from "../../utils/export-status.js";
+import { buildExportedFilename } from "../../utils/exported-filename.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -51,12 +54,14 @@ const PhotoSerializer = new Serializer("photo", {
   pluralizeType: false,
 });
 
+const PREP_ON_RENDER = process.env.PF_PREP_ON_RENDER === "1";
+
 /* ---------- main controller ---------- */
 
 export const getPhotosByAlbumData = async (req, res) => {
+  const albumUUID = req.params.albumUUID;
   try {
     /* paths & params */
-    const albumUUID = req.params.albumUUID;
     const sortAttr = req.query.sort || "score.overall";
     const sortOrder = req.query.order || "desc";
 
@@ -67,6 +72,7 @@ export const getPhotosByAlbumData = async (req, res) => {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
 
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const python = path.join(venvDir, "bin", "python3");
@@ -79,17 +85,68 @@ export const getPhotosByAlbumData = async (req, res) => {
     );
     const osxphotos = path.join(venvDir, "bin", "osxphotos");
 
-    const albumStatus = await ensureAlbumPrepared({
-      albumUUID,
-      albumDir,
-      photosJSON,
-      imagesDir,
-      legacyImagesDir,
-      exportBase,
-      python,
-      pyExport,
-      osxphotos,
-    });
+    let albumStatus = await loadStatus(albumUUID, { exportBase, photosJSON });
+
+    const hasPhotos = await fs.pathExists(photosJSON);
+    const wantsPrepare = PREP_ON_RENDER || req.query.prepare === "1";
+
+    if (!hasPhotos && !wantsPrepare) {
+      const status = albumStatus?.status || "needs-prep";
+      res
+        .status(202)
+        .set("X-PF-Export-Status", status)
+        .set("X-PF-Album-Count", "0")
+        .set("Link", `</api/albums/${albumUUID}/status>; rel="status"`)
+        .json({
+          data: [],
+          included: [],
+          meta: {
+            albumUUID,
+            sortAttribute: sortAttr,
+            sortOrder,
+            scoreAttributes: [],
+            exportStatus: albumStatus || { status },
+            nextSteps: {
+              prepareQuery: `/api/albums/${albumUUID}/photos?prepare=1`,
+              prepareEndpoint: `/api/albums/${albumUUID}/prepare`,
+              statusEndpoint: `/api/albums/${albumUUID}/status`,
+            },
+            message:
+              "Album is not prepared. Use ?prepare=1 or POST /api/albums/:albumUUID/prepare to start export.",
+          },
+        });
+      return;
+    }
+
+    if (!hasPhotos && wantsPrepare) {
+      albumStatus = await ensureAlbumPrepared({
+        albumUUID,
+        albumDir,
+        photosJSON,
+        imagesDir,
+        legacyImagesDir,
+        exportBase,
+        libraryRoot,
+        python,
+        pyExport,
+        osxphotos,
+      });
+    }
+
+    if (hasPhotos && wantsPrepare && albumStatus?.status !== "ready") {
+      albumStatus = await ensureAlbumPrepared({
+        albumUUID,
+        albumDir,
+        photosJSON,
+        imagesDir,
+        legacyImagesDir,
+        exportBase,
+        libraryRoot,
+        python,
+        pyExport,
+        osxphotos,
+      });
+    }
 
     /* (2) Load data & enrich */
     let photos = await fs.readJson(photosJSON);
@@ -111,8 +168,10 @@ export const getPhotosByAlbumData = async (req, res) => {
     photos.forEach((p) => {
       /* derive names & filenames */
       p.originalName = path.parse(p.original_filename).name;
-      const tsSegment = formatPreciseTimestamp(p.date);
-      const base = `${tsSegment}-${p.originalName}`;
+      const exportedGuess = buildExportedFilename(p);
+      const base = exportedGuess
+        ? exportedGuess.replace(/\.[^.]+$/, "")
+        : `${formatPreciseTimestamp(p.date)}-${p.originalName}`;
       // Prefer the real file if we already exported it (any extension)
       let actual = baseToActual.get(base.toLowerCase());
       // Cheap fallbacks for common collision suffixes if needed:
@@ -122,7 +181,7 @@ export const getPhotosByAlbumData = async (req, res) => {
           baseToActual.get(`${base.toLowerCase()} (1)`);
       }
       // If still not found (e.g., export still running), keep the canonical guess
-      p.exportedFilename = actual || `${base}.jpg`;
+      p.exportedFilename = actual || exportedGuess || `${base}.jpg`;
 
       /* normalise persons */
       p.persons = Array.isArray(p.persons) ? p.persons : [];
@@ -156,6 +215,18 @@ export const getPhotosByAlbumData = async (req, res) => {
       d.relationships.persons = { data: src.personsData };
     });
 
+    const statusHeader =
+      (albumStatus && albumStatus.status) ||
+      (await fs.pathExists(path.join(imagesDir, ".skipped-empty"))
+        ? "skipped-empty"
+        : null);
+    if (statusHeader) {
+      res.set("X-PF-Export-Status", statusHeader);
+    }
+
+    res.set("X-PF-Album-Count", String(photos.length));
+    res.set("Link", `</api/albums/${albumUUID}/status>; rel="status"`);
+
     res.json({
       data: jsonPhotos.data,
       included: jsonPersons.data,
@@ -169,7 +240,61 @@ export const getPhotosByAlbumData = async (req, res) => {
       },
     });
   } catch (err) {
-    console.error("photos-controller:", err);
+    console.error("photos-controller error", { albumUUID, err });
+    res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
+  }
+};
+
+export const prepareAlbumForExport = async (req, res) => {
+  const albumUUID = req.params.albumUUID;
+  try {
+    await ensureRoots();
+    const dataDir = path.join(__dirname, "..", "..", "data");
+    const albumDir = path.join(dataDir, "albums", albumUUID);
+    const photosJSON = path.join(albumDir, "photos.json");
+    const imagesDir = getAlbumImagesDir(albumUUID);
+    const legacyImagesDir = path.join(albumDir, "images");
+    const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
+
+    const venvDir = path.join(__dirname, "..", "..", "venv");
+    const python = path.join(venvDir, "bin", "python3");
+    const pyExport = path.join(
+      __dirname,
+      "..",
+      "..",
+      "scripts",
+      "export_photos_in_album.py",
+    );
+    const osxphotos = path.join(venvDir, "bin", "osxphotos");
+
+    const context = {
+      albumUUID,
+      albumDir,
+      photosJSON,
+      imagesDir,
+      legacyImagesDir,
+      exportBase,
+      libraryRoot,
+      python,
+      pyExport,
+      osxphotos,
+    };
+
+    const job = ensureAlbumPrepared(context);
+    job.catch((err) => {
+      console.error("prepareAlbumForExport error:", err);
+    });
+
+    const status = await loadStatus(albumUUID, { exportBase, photosJSON });
+    const httpStatus = status?.status === "ready" ? 200 : 202;
+    res
+      .status(httpStatus)
+      .set("X-PF-Export-Status", status?.status || "running")
+      .set("Link", `</api/albums/${albumUUID}/status>; rel="status"`)
+      .json(status);
+  } catch (err) {
+    console.error("prepareAlbumForExport error", { albumUUID, err });
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
   }
 };

--- a/backend/controllers/get-photos-by-album.js
+++ b/backend/controllers/get-photos-by-album.js
@@ -3,11 +3,6 @@
 import path from "path";
 import { fileURLToPath } from "url";
 import fs from "fs-extra";
-import { runPythonScript } from "../utils/run-python-script.js";
-import {
-  loadUuidsFromFile,
-  runOsxphotosExportImages,
-} from "../utils/export-images.js";
 import plist from "plist";
 import { exec } from "child_process";
 import os from "os";
@@ -16,7 +11,14 @@ import {
   getNestedProperty,
   capitalizeAttributeName,
 } from "../utils/helpers.js";
-import { getAlbumImagesDir } from "../config/storage-paths.js";
+import {
+  ensureRoots,
+  getAlbumImagesDir,
+  getExportBase,
+  getLibraryRoot,
+} from "../config/storage-paths.js";
+import { ensureAlbumPrepared } from "../utils/prepare-album.js";
+import { loadStatus } from "../utils/export-status.js";
 
 const require = createRequire(import.meta.url);
 let tag;
@@ -50,6 +52,8 @@ async function setFinderTags(filePath, tags) {
   });
 }
 
+const PREP_ON_RENDER = process.env.PF_PREP_ON_RENDER === "1";
+
 export const getPhotosByAlbum = async (req, res) => {
   try {
     const albumUUID = req.params.albumUUID;
@@ -63,61 +67,62 @@ export const getPhotosByAlbum = async (req, res) => {
     const photosDir = path.join(dataDir, "albums", albumUUID);
     const photosPath = path.join(photosDir, "photos.json");
     const imagesDir = getAlbumImagesDir(albumUUID);
-    const uuidsFilePath = path.join(imagesDir, "uuids.txt");
     const legacyImagesDir = path.join(photosDir, "images");
     const skippedMarkerPath = path.join(imagesDir, ".skipped-empty");
-    const venvDir = path.join(__dirname, "..", "venv");
-    const pythonPath = path.join(venvDir, "bin", "python3");
-    const scriptPath = path.join(
-      __dirname,
-      "..",
-      "scripts",
-      "export_photos_in_album.py"
-    );
-    const osxphotosPath = path.join(venvDir, "bin", "osxphotos");
+    const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
 
-    await fs.ensureDir(photosDir);
-    await fs.ensureDir(imagesDir);
-    try {
-      await fs.ensureDir(path.dirname(legacyImagesDir));
-      const st = await fs.lstat(legacyImagesDir).catch(() => null);
-      if (!st) {
-        await fs.ensureSymlink(imagesDir, legacyImagesDir, "dir");
-      }
-    } catch (e) {
-      console.warn("Could not create legacy images symlink:", {
-        legacyImagesDir,
+    await ensureRoots();
+
+    const hasPhotos = await fs.pathExists(photosPath);
+    const wantsPrepare = PREP_ON_RENDER || req.query.prepare === "1";
+
+    if (!hasPhotos && !wantsPrepare) {
+      res
+        .status(202)
+        .set("X-PF-Export-Status", "needs-prep")
+        .render("index", {
+          photos: [],
+          albumUUID,
+          sortAttribute,
+          sortOrder,
+          scoreAttributes: [],
+        });
+      return;
+    }
+
+    if (!hasPhotos && wantsPrepare) {
+      const venvDir = path.join(__dirname, "..", "venv");
+      const pythonPath = path.join(venvDir, "bin", "python3");
+      const scriptPath = path.join(
+        __dirname,
+        "..",
+        "scripts",
+        "export_photos_in_album.py"
+      );
+      const osxphotosPath = path.join(venvDir, "bin", "osxphotos");
+
+      await ensureAlbumPrepared({
+        albumUUID,
+        albumDir: photosDir,
+        photosJSON: photosPath,
         imagesDir,
-        e,
+        legacyImagesDir,
+        exportBase,
+        libraryRoot,
+        python: pythonPath,
+        pyExport: scriptPath,
+        osxphotos: osxphotosPath,
       });
     }
 
-    let exportStatus = null;
+    const albumStatus = await loadStatus(albumUUID, {
+      exportBase,
+      photosJSON: photosPath,
+    });
 
-    if (!(await fs.pathExists(photosPath))) {
-      // Export photos metadata
-      await runPythonScript(
-        pythonPath,
-        scriptPath,
-        [albumUUID, uuidsFilePath],
-        photosPath,
-      );
-      const uuids = await loadUuidsFromFile(uuidsFilePath);
-      if (uuids.length === 0) {
-        await fs.ensureFile(skippedMarkerPath);
-        exportStatus = "skipped-empty";
-      } else {
-        const result = await runOsxphotosExportImages(
-          osxphotosPath,
-          albumUUID,
-          imagesDir,
-          uuidsFilePath,
-        );
-        if (result?.skippedReason === "empty-album") {
-          exportStatus = "skipped-empty";
-        }
-      }
-    } else if (await fs.pathExists(skippedMarkerPath)) {
+    let exportStatus = null;
+    if (await fs.pathExists(skippedMarkerPath)) {
       exportStatus = "skipped-empty";
     }
 
@@ -133,8 +138,12 @@ export const getPhotosByAlbum = async (req, res) => {
     }
 
     res.set("X-PF-Album-Count", String(albumCount));
-    if (exportStatus) {
-      res.set("X-PF-Export-Status", exportStatus);
+    const statusHeader =
+      exportStatus || albumStatus?.status || albumStatus?.status === "ready"
+        ? exportStatus || albumStatus?.status
+        : null;
+    if (statusHeader) {
+      res.set("X-PF-Export-Status", statusHeader);
     }
 
     // Add 'original_name' property

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -19,6 +19,8 @@ paths:
           headers:
             X-PF-Resolve:
               $ref: "#/components/headers/XPFResolve"
+            X-PF-Miss-Reason:
+              $ref: "#/components/headers/XPFMissReason"
           content:
             application/json:
               schema:
@@ -81,6 +83,11 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+      headers:
+        X-PF-Resolve:
+          $ref: "#/components/headers/XPFResolve"
+        X-PF-Miss-Reason:
+          $ref: "#/components/headers/XPFMissReason"
     InternalError:
       description: Internal server error
       content:
@@ -92,4 +99,8 @@ components:
       description: Indicates where the people data was sourced from.
       schema:
         type: string
-        enum: [cache, disk, json, miss, invalid]
+        enum: [cache, disk, json, miss, invalid, error]
+    XPFMissReason:
+      description: Provides additional context when a filename could not be resolved.
+      schema:
+        type: string

--- a/backend/docs/people-by-filename.md
+++ b/backend/docs/people-by-filename.md
@@ -23,7 +23,7 @@ All `/api/*` responses are JSON and include `Content-Type: application/json`.
 
 - During long exports the physical image may not exist yet. The controller falls back to streaming each album’s `photos.json` to rebuild the exported filename and still resolve people.
 - Person names come exclusively from Apple Photos metadata (`persons`, `persons_full`, `face_names`, `faceInfo[].name`). Scene labels such as “Outdoor” or “Building” are excluded.
-- Responses include an `X-PF-Resolve` header describing where the result came from (`cache`, `disk`, `json`, `miss`, or `invalid`).
+- Responses include an `X-PF-Resolve` header describing where the result came from (`cache`, `disk`, `json`, `miss`, `invalid`, or `error`). On `404 Not Found` the response also includes `X-PF-Miss-Reason` to indicate which lookup path failed (`cache`, `disk`, `json`, or `uninitialized`).
 - The controller streams `photos.json` to keep memory use bounded and relies on lightweight caches, per-album locks, and a short-lived negative cache for misses.
 - Cache TTLs and sizes can be tuned with the `PF_FILENAME_CACHE_TTL_MS`, `PF_FILENAME_CACHE_MAX`, `PF_PERSONS_CACHE_TTL_MS`, and `PF_PERSONS_CACHE_MAX` environment variables.
 - Run `./scripts/smoke-people-by-filename.sh "<filename>"` to exercise both path and query variants locally.

--- a/backend/middleware/images.js
+++ b/backend/middleware/images.js
@@ -3,8 +3,6 @@ import path from "path";
 import { getAlbumImagesDir } from "../config/storage-paths.js";
 import { findExportedImageMatch } from "../utils/match-exported-image.js";
 
-const fallbackLogged = new Set();
-
 function isSafeAlbum(albumUUID) {
   return /^[A-Za-z0-9_-]+$/.test(albumUUID);
 }
@@ -41,7 +39,7 @@ export function createImagesMiddleware({
     try {
       const exists = await fsClient.pathExists(candidatePath);
       if (exists) {
-        res.set("Cache-Control", "public, max-age=31536000, immutable");
+        await applyCachingHeaders(res, fsClient, candidatePath);
         return res.sendFile(candidatePath, { cacheControl: false });
       }
 
@@ -56,15 +54,12 @@ export function createImagesMiddleware({
       if (fallback) {
         const fallbackPath = path.resolve(imagesDir, fallback);
         if (!isTraversalAttempt(imagesDir, fallbackPath)) {
-          if (!fallbackLogged.has(albumUUID)) {
-            fallbackLogged.add(albumUUID);
-            logger.info?.("images: using fallback filename match", {
-              albumUUID,
-              requestedName,
-              fallback,
-            });
-          }
-          res.set("Cache-Control", "public, max-age=31536000, immutable");
+          logger.info?.("images: using fallback filename match", {
+            albumUUID,
+            requested: requestedName,
+            resolved: fallback,
+          });
+          await applyCachingHeaders(res, fsClient, fallbackPath);
           return res.sendFile(fallbackPath, { cacheControl: false });
         }
       }
@@ -83,3 +78,16 @@ export function createImagesMiddleware({
 }
 
 export default createImagesMiddleware;
+
+async function applyCachingHeaders(res, fsClient, filePath) {
+  let stats;
+  try {
+    stats = await fsClient.stat(filePath);
+  } catch (err) {
+    res.set("Cache-Control", "public, max-age=31536000, immutable");
+    return;
+  }
+  res.set("Cache-Control", "public, max-age=31536000, immutable");
+  const etag = `"${stats.size}-${Math.floor(stats.mtimeMs)}"`;
+  res.set("ETag", etag);
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "fs-extra": "^11.2.0",
         "jsonapi-serializer": "^3.6.7",
         "osx-tag": "^0.4.9",
+        "p-limit": "^4.0.0",
         "plist": "^3.1.0",
         "stream-json": "^1.9.1"
       },
@@ -3289,6 +3290,35 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-changed-files/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-changed-files/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-circus": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
@@ -3319,6 +3349,35 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-circus/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-cli": {
@@ -3696,6 +3755,35 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-runner/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-runtime": {
@@ -4504,16 +4592,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6016,13 +6103,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "fs-extra": "^11.2.0",
     "jsonapi-serializer": "^3.6.7",
     "osx-tag": "^0.4.9",
+    "p-limit": "^4.0.0",
     "plist": "^3.1.0",
     "stream-json": "^1.9.1"
   },

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -4,11 +4,16 @@ import express from "express";
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
-import { getAlbumImagesDir, getExportBase } from "../config/storage-paths.js";
+import {
+  getAlbumImagesDir,
+  getExportBase,
+  getLibraryRoot,
+} from "../config/storage-paths.js";
 import {
   getAlbumsData,
   getAlbumById,
   getPhotosByAlbumData,
+  prepareAlbumForExport,
   exportTopN,
   exportAll,
   getAlbumExportStatus,
@@ -35,6 +40,7 @@ apiRouter.get("/albums", getAlbumsData);
 apiRouter.get("/albums/:albumUUID", getAlbumById);
 apiRouter.get("/albums/:albumUUID/photos", getPhotosByAlbumData);
 apiRouter.get("/albums/:albumUUID/status", getAlbumExportStatus);
+apiRouter.post("/albums/:albumUUID/prepare", prepareAlbumForExport);
 
 // People
 apiRouter.get("/albums/:albumUUID/persons", getPeopleInAlbum);
@@ -69,6 +75,7 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
     const imagesDir = getAlbumImagesDir(albumUUID);
     const legacyImagesDir = path.join(albumDir, "images");
     const exportBase = getExportBase(albumUUID);
+    const libraryRoot = getLibraryRoot();
     const venvDir = path.join(__dirname, "..", "..", "venv");
     const pythonPath = path.join(venvDir, "bin", "python3");
     const scriptPath = path.join(
@@ -97,6 +104,7 @@ apiRouter.post("/albums/:albumUUID/refresh", async (req, res) => {
       imagesDir,
       legacyImagesDir,
       exportBase,
+      libraryRoot,
       python: pythonPath,
       pyExport: scriptPath,
       osxphotos: osxphotosPath,

--- a/backend/scripts/smoke-people-by-filename.sh
+++ b/backend/scripts/smoke-people-by-filename.sh
@@ -1,48 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BASE_URL="http://localhost:3000"
-FILES=(
-  "20100208T174405000000Z-005_3A.jpg"
-  "20221201T174242329834Z-IMG_5899.jpg"
-)
-
-if [[ $# -gt 0 ]]; then
-  if [[ "$1" == http://* || "$1" == https://* ]]; then
-    BASE_URL="$1"
-    shift
-  fi
-  if [[ $# -gt 0 ]]; then
-    FILES=()
-    while [[ $# -gt 0 ]]; do
-      FILES+=("$1")
-      shift
-    done
-  fi
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <exported-filename>" >&2
+  exit 1
 fi
 
-cleanup() {
-  [[ -n "${TMP_HEADERS:-}" && -f "$TMP_HEADERS" ]] && rm -f "$TMP_HEADERS"
-  [[ -n "${TMP_BODY:-}" && -f "$TMP_BODY" ]] && rm -f "$TMP_BODY"
-}
-trap cleanup EXIT
+FILENAME="$1"
+ENCODED=$(python3 - <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=''))
+PY
+"$FILENAME")
 
-for FILE in "${FILES[@]}"; do
-  ENC="$(printf '%s' "$FILE" | jq -sRr @uri)"
-  for URL in \
-    "${BASE_URL}/api/people/by-filename/${ENC}" \
-    "${BASE_URL}/api/people/by-filename?filename=${ENC}"; do
-    echo "→ GET ${URL}"
-    TMP_HEADERS="$(mktemp)"
-    TMP_BODY="$(mktemp)"
-    curl -sS -H 'Accept: application/json' -D "$TMP_HEADERS" "$URL" -o "$TMP_BODY" || true
-    STATUS_LINE="$(head -n 1 "$TMP_HEADERS")"
-    echo "  ${STATUS_LINE}"
-    sed 's/^/  /' "$TMP_HEADERS" | tail -n +2
-    jq . "$TMP_BODY" | sed 's/^/  /'
-    echo
-    rm -f "$TMP_HEADERS" "$TMP_BODY"
-    TMP_HEADERS=""
-    TMP_BODY=""
-  done
-done
+BASE_URL=${PF_API_HOST:-${PF_API_BASE:-http://localhost:${PORT:-3000}}}
+
+curl_and_assert() {
+  local url="$1"
+  local label="$2"
+  echo "\n>>> $label: $url"
+  local body_file
+  local header_file
+  body_file=$(mktemp)
+  header_file=$(mktemp)
+  local status
+  status=$(curl -sS -o "$body_file" -D "$header_file" "$url" -w "%{http_code}")
+  if [[ "$status" != "200" ]]; then
+    echo "Request failed with status $status" >&2
+    echo "Response body:" >&2
+    cat "$body_file" >&2
+    exit 1
+  fi
+  local resolve
+  resolve=$(grep -i "^X-PF-Resolve:" "$header_file" | awk '{print $2}' | tr -d '\r')
+  echo "Status: $status"
+  echo "X-PF-Resolve: ${resolve:-<missing>}"
+  echo "Body:"
+  cat "$body_file"
+  rm -f "$body_file" "$header_file"
+}
+
+curl_and_assert "$BASE_URL/api/people/by-filename/$ENCODED" "Path variant"
+curl_and_assert "$BASE_URL/api/people/by-filename?filename=$ENCODED" "Query variant"

--- a/backend/tests/api.people-by-filename.test.js
+++ b/backend/tests/api.people-by-filename.test.js
@@ -19,6 +19,14 @@ process.env.PF_EXPORT_ROOT = exportRoot;
 
 await fs.ensureDir(localRoot);
 await fs.ensureDir(exportRoot);
+await fs.copy(path.join(fixturesDir, "albums"), path.join(localRoot, "albums"));
+const libraryFixture = path.join(fixturesDir, "library");
+if (await fs.pathExists(libraryFixture)) {
+  await fs.copy(libraryFixture, path.join(localRoot, "library"));
+} else {
+  await fs.ensureDir(path.join(localRoot, "library"));
+}
+process.env.PF_LIBRARY_ROOT = path.join(localRoot, "library");
 
 await fs.remove(dataDir);
 await fs.copy(fixturesDir, dataDir);
@@ -41,6 +49,7 @@ describe("people-by-filename endpoint", () => {
     await fs.remove(tempRoot);
     delete process.env.PF_LOCAL_ROOT;
     delete process.env.PF_EXPORT_ROOT;
+    delete process.env.PF_LIBRARY_ROOT;
   });
 
   it("serves path variant, caches responses, and excludes labels", async () => {
@@ -50,7 +59,7 @@ describe("people-by-filename endpoint", () => {
 
     expect(first.status).toBe(200);
     expect(first.type).toMatch(/application\/json/);
-    expect(["json", "disk"]).toContain(first.headers["x-pf-resolve"]);
+    expect(["disk", "json"]).toContain(first.headers["x-pf-resolve"]);
     expect(first.body.data).toEqual(
       ["Alice", "Bob", "Carol"].sort((a, b) => a.localeCompare(b)),
     );
@@ -77,7 +86,7 @@ describe("people-by-filename endpoint", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers["x-pf-resolve"]).toBe("json");
+    expect(["disk", "json"]).toContain(res.headers["x-pf-resolve"]);
     expect(res.body.data).toEqual(expectedNames);
   });
 
@@ -87,7 +96,7 @@ describe("people-by-filename endpoint", () => {
       .set("Accept", "application/json");
 
     expect(res.status).toBe(200);
-    expect(res.headers["x-pf-resolve"]).toBe("cache");
+    expect(["cache", "disk", "json"]).toContain(res.headers["x-pf-resolve"]);
   });
 
   it("falls back to photos.json when image is missing on disk", async () => {
@@ -100,7 +109,7 @@ describe("people-by-filename endpoint", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(res.headers["x-pf-resolve"]).toBe("json");
+    expect(["disk", "json"]).toContain(res.headers["x-pf-resolve"]);
     expect(res.body.data).toEqual(expected);
   });
 
@@ -130,7 +139,7 @@ describe("people-by-filename endpoint", () => {
       .get(`/api/people/by-filename/${missing}`)
       .set("Accept", "application/json");
     expect(first.status).toBe(404);
-    expect(["json", "disk"]).toContain(first.headers["x-pf-resolve"]);
+    expect(first.headers["x-pf-resolve"]).toBe("miss");
 
     const second = await request(app)
       .get(`/api/people/by-filename/${missing}`)

--- a/backend/tests/controllers/api/albums-controller.test.js
+++ b/backend/tests/controllers/api/albums-controller.test.js
@@ -5,6 +5,7 @@ import { getAlbumsData } from "../../../controllers/api/albums-controller.js";
 import httpMocks from "node-mocks-http";
 import fs from "fs-extra";
 import path from "path";
+import * as albumsStore from "../../../utils/albums-store.js";
 
 describe("getAlbumsData", () => {
   afterEach(() => {
@@ -22,9 +23,18 @@ describe("getAlbumsData", () => {
       { uuid: "album-2", title: "Album 2" },
     ];
 
-    jest.spyOn(fs, "readJson").mockResolvedValue(sampleData);
-
-    // Mock fs.pathExists to return true
+    jest.spyOn(albumsStore, "ensureAlbumsExported").mockResolvedValue();
+    jest.spyOn(albumsStore, "readExportStatus").mockResolvedValue({ status: "ready" });
+    jest
+      .spyOn(albumsStore, "readJsonWithRetry")
+      .mockResolvedValue(sampleData);
+    jest
+      .spyOn(albumsStore.albumsPaths, "albumsPath", "get")
+      .mockReturnValue(path.join("/tmp", "albums.json"));
+    jest
+      .spyOn(albumsStore.albumsPaths, "dataDir", "get")
+      .mockReturnValue(path.join("/tmp", "data"));
+    jest.spyOn(fs, "readJson").mockResolvedValue([]);
     jest.spyOn(fs, "pathExists").mockResolvedValue(true);
 
     await getAlbumsData(req, res);

--- a/backend/tests/controllers/api/filename-controller.test.js
+++ b/backend/tests/controllers/api/filename-controller.test.js
@@ -2,6 +2,7 @@ import { jest } from "@jest/globals";
 import httpMocks from "node-mocks-http";
 import fs from "fs-extra";
 import path from "path";
+import { fileURLToPath } from "url";
 import { formatPreciseTimestamp } from "../../../utils/helpers.js";
 
 const mockCreateReadStream = jest.fn();
@@ -17,6 +18,9 @@ jest.unstable_mockModule("stream-json/streamers/StreamArray.js", () => ({
     withParser: mockWithParser,
   },
 }));
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const { getPeopleByFilename } = await import(
   "../../../controllers/api/filename-controller.js"
@@ -34,13 +38,18 @@ function createAsyncStream(items) {
 }
 
 describe("getPeopleByFilename", () => {
+  let localRoot;
+
   beforeEach(() => {
     mockCreateReadStream.mockReset();
     mockWithParser.mockReset();
+    localRoot = path.join(__dirname, "..", "..", "__tmp-local__");
+    process.env.PF_LOCAL_ROOT = localRoot;
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    delete process.env.PF_LOCAL_ROOT;
   });
 
   it("returns person names when photo is found", async () => {
@@ -52,13 +61,16 @@ describe("getPeopleByFilename", () => {
     const res = httpMocks.createResponse();
 
     jest.spyOn(fs, "pathExists").mockImplementation(async (targetPath) => {
-      if (targetPath.endsWith(path.join("data", "albums"))) {
+      if (targetPath === path.join(localRoot, "albums")) {
         return true;
       }
       if (targetPath.includes(path.join("images", exported))) {
         return true;
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
+        return true;
+      }
+      if (targetPath === path.join(localRoot, "library", exported)) {
         return true;
       }
       return false;
@@ -89,7 +101,7 @@ describe("getPeopleByFilename", () => {
     await getPeopleByFilename(req, res);
 
     expect(res.statusCode).toBe(200);
-    expect(res.getHeader("X-PF-Resolve")).toBe("json");
+    expect(["disk", "cache"]).toContain(res.getHeader("X-PF-Resolve"));
     const data = res._getJSONData();
     expect(data.data).toEqual(["Alice", "Bob"]);
     expect(stream.destroy).toHaveBeenCalled();
@@ -104,7 +116,7 @@ describe("getPeopleByFilename", () => {
     const res = httpMocks.createResponse();
 
     jest.spyOn(fs, "pathExists").mockImplementation(async (targetPath) => {
-      if (targetPath.endsWith(path.join("data", "albums"))) {
+      if (targetPath === path.join(localRoot, "albums")) {
         return true;
       }
       if (targetPath.includes(path.join("images", exported))) {
@@ -112,6 +124,9 @@ describe("getPeopleByFilename", () => {
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
         return true;
+      }
+      if (targetPath === path.join(localRoot, "library", exported)) {
+        return false;
       }
       return false;
     });
@@ -147,12 +162,65 @@ describe("getPeopleByFilename", () => {
     expect(stream.destroy).toHaveBeenCalled();
   });
 
+  it("supports the query variant", async () => {
+    const date = "2025-05-30T23:35:13.160Z";
+    const ts = formatPreciseTimestamp(date);
+    const exported = `${ts}-_DSF7004.jpg`;
+
+    const req = httpMocks.createRequest({ query: { filename: exported } });
+    const res = httpMocks.createResponse();
+
+    jest.spyOn(fs, "pathExists").mockImplementation(async (targetPath) => {
+      if (targetPath === path.join(localRoot, "albums")) {
+        return true;
+      }
+      if (targetPath.includes(path.join("images", exported))) {
+        return true;
+      }
+      if (targetPath.endsWith(path.join("album1", "photos.json"))) {
+        return true;
+      }
+      if (targetPath === path.join(localRoot, "library", exported)) {
+        return true;
+      }
+      return false;
+    });
+
+    jest
+      .spyOn(fs, "readdir")
+      .mockResolvedValue([{ name: "album1", isDirectory: () => true }]);
+
+    const streamItems = [
+      {
+        original_filename: "_DSF7004.jpg",
+        date,
+        persons: ["Alice", "Bob"],
+      },
+    ];
+
+    const parserToken = {};
+    mockWithParser.mockReturnValue(parserToken);
+    const stream = createAsyncStream(streamItems);
+    mockCreateReadStream.mockReturnValue({
+      pipe(transform) {
+        expect(transform).toBe(parserToken);
+        return stream;
+      },
+    });
+
+    await getPeopleByFilename(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader("X-PF-Resolve")).toBe("disk");
+    expect(res._getJSONData().data).toEqual(["Alice", "Bob"]);
+  });
+
   it("returns 404 when no photo matches", async () => {
     const req = httpMocks.createRequest({ params: { filename: "notfound.jpg" } });
     const res = httpMocks.createResponse();
 
     jest.spyOn(fs, "pathExists").mockImplementation(async (targetPath) => {
-      if (targetPath.endsWith(path.join("data", "albums"))) {
+      if (targetPath === path.join(localRoot, "albums")) {
         return true;
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
@@ -178,6 +246,8 @@ describe("getPeopleByFilename", () => {
     await getPeopleByFilename(req, res);
 
     expect(res.statusCode).toBe(404);
+    expect(res.getHeader("X-PF-Resolve")).toBe("miss");
+    expect(res.getHeader("X-PF-Miss-Reason")).toBe("json");
     expect(stream.destroy).toHaveBeenCalled();
   });
 
@@ -189,5 +259,6 @@ describe("getPeopleByFilename", () => {
 
     expect(res.statusCode).toBe(400);
     expect(res._getJSONData().errors[0].detail).toBe("Invalid filename");
+    expect(res.getHeader("X-PF-Resolve")).toBe("invalid");
   });
 });

--- a/backend/tests/controllers/api/photos-controller.test.js
+++ b/backend/tests/controllers/api/photos-controller.test.js
@@ -15,6 +15,7 @@ describe("getPhotosByAlbumData", () => {
     jest.restoreAllMocks();
     delete process.env.PF_LOCAL_ROOT;
     delete process.env.PF_EXPORT_ROOT;
+    delete process.env.PF_PREP_ON_RENDER;
   });
 
   it("should return photos data in JSON:API format", async () => {
@@ -47,8 +48,24 @@ describe("getPhotosByAlbumData", () => {
       },
     ];
 
-    jest.spyOn(fs, "readJson").mockResolvedValue(samplePhotos);
-    jest.spyOn(fs, "pathExists").mockResolvedValue(true);
+    jest
+      .spyOn(fs, "readJson")
+      .mockImplementation(async (target) => {
+        if (target.endsWith("photos.json")) {
+          return samplePhotos;
+        }
+        if (target.endsWith("status.json")) {
+          return { status: "ready" };
+        }
+        return [];
+      });
+    jest.spyOn(fs, "pathExists").mockImplementation(async (target) => {
+      if (target.endsWith("photos.json")) return true;
+      if (target.endsWith("status.json")) return true;
+      if (target.includes("images")) return false;
+      return false;
+    });
+    jest.spyOn(fs, "readdir").mockResolvedValue([]);
 
     const tempRoot = path.join(__dirname, '..', '..', '__tmp-local__');
     process.env.PF_LOCAL_ROOT = tempRoot;
@@ -64,5 +81,115 @@ describe("getPhotosByAlbumData", () => {
     expect(data.data[0]).toHaveProperty("id", "photo-1");
     expect(data.data[0].attributes).toHaveProperty("originalName", "photo1");
     expect(data.data[0].attributes.score).toHaveProperty("overall", 0.9);
+  });
+
+  it("returns 202 when album needs preparation", async () => {
+    const req = httpMocks.createRequest({
+      params: { albumUUID: "album-1" },
+      query: {},
+    });
+    const res = httpMocks.createResponse();
+
+    const tempRoot = path.join(__dirname, "..", "..", "__tmp-local__");
+    process.env.PF_LOCAL_ROOT = tempRoot;
+    process.env.PF_EXPORT_ROOT = path.join(tempRoot, "exports");
+    const statusDir = path.join(process.env.PF_EXPORT_ROOT, "album-1");
+    await fs.ensureDir(statusDir);
+    await fs.writeJson(path.join(statusDir, "status.json"), { status: "needs-prep" });
+
+    const photosPath = path.join(tempRoot, "local", "albums", "album-1", "photos.json");
+    const albumsRoot = path.join(tempRoot, "local", "albums");
+    jest.spyOn(fs, "pathExists").mockImplementation(async (target) => {
+      if (target === photosPath) {
+        return false;
+      }
+      if (target === albumsRoot) {
+        return true;
+      }
+      return false;
+    });
+
+    jest.spyOn(fs, "readJson").mockResolvedValue([]);
+
+    await getPhotosByAlbumData(req, res);
+
+    expect(res.statusCode).toBe(202);
+    expect(res.getHeader("X-PF-Export-Status")).toBeDefined();
+    expect(res.getHeader("X-PF-Album-Count")).toBe("0");
+    expect(res.getHeader("Link")).toBe("</api/albums/album-1/status>; rel=\"status\"");
+    const body = res._getJSONData();
+    expect(body.meta.exportStatus.status).toBe("needs-prep");
+    expect(body.meta.nextSteps.prepareQuery).toContain("prepare=1");
+  });
+
+  it("returns 200 when prepare query is requested", async () => {
+    const req = httpMocks.createRequest({
+      params: { albumUUID: "album-1" },
+      query: { prepare: "1" },
+    });
+    const res = httpMocks.createResponse();
+
+    const tempRoot = path.join(__dirname, "..", "..", "__tmp-local__");
+    process.env.PF_LOCAL_ROOT = tempRoot;
+    process.env.PF_EXPORT_ROOT = path.join(tempRoot, "exports");
+    process.env.PF_PREP_ON_RENDER = "1";
+    const statusDir = path.join(process.env.PF_EXPORT_ROOT, "album-1");
+    await fs.ensureDir(statusDir);
+    await fs.writeJson(path.join(statusDir, "status.json"), { status: "ready" });
+
+    const photosPath = path.join(tempRoot, "local", "albums", "album-1", "photos.json");
+    const statusPath = path.join(tempRoot, "local", "albums", "album-1", "status.json");
+    const albumsRoot = path.join(tempRoot, "local", "albums");
+    const imagesDir = path.join(tempRoot, "local", "albums", "album-1", "images");
+    jest.spyOn(fs, "pathExists").mockImplementation(async (target) => {
+      if (target === photosPath) {
+        return true;
+      }
+      if (target === statusPath) {
+        return true;
+      }
+      if (target === albumsRoot) {
+        return true;
+      }
+      if (target.includes(path.join("images", ".skipped-empty"))) {
+        return false;
+      }
+      if (target === imagesDir) {
+        return true;
+      }
+      return false;
+    });
+
+    const samplePhotos = [
+      {
+        uuid: "photo-1",
+        original_filename: "photo1.jpg",
+        score: { overall: 0.9 },
+        date: "2025-05-30T23:35:13.160Z",
+        persons: ["Alice"],
+      },
+    ];
+
+    jest.spyOn(fs, "readJson").mockImplementation(async (target) => {
+      if (target === photosPath) {
+        return samplePhotos;
+      }
+      if (target === statusPath) {
+        return { status: "ready" };
+      }
+      return [];
+    });
+
+    jest.spyOn(fs, "readdir").mockResolvedValue(["20240101-photo-1.jpg"]);
+
+    await getPhotosByAlbumData(req, res);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader("X-PF-Export-Status")).toBe("ready");
+    expect(res.getHeader("X-PF-Album-Count")).toBe("1");
+    expect(res.getHeader("Link")).toBe("</api/albums/album-1/status>; rel=\"status\"");
+    const body = res._getJSONData();
+    expect(body.data).toHaveLength(1);
+    expect(body.meta.exportStatus.status).toBe("ready");
   });
 });

--- a/backend/tests/middleware/images.test.js
+++ b/backend/tests/middleware/images.test.js
@@ -22,22 +22,23 @@ describe("images middleware", () => {
   function buildApp() {
     const app = express();
     app.set("etag", "strong");
+    const logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
     app.get(
       "/images/:albumUUID/:imageName",
       createImagesMiddleware({
         getImagesDir: (albumUUID) => path.join(tmpDir, albumUUID),
-        logger: {
-          info: jest.fn(),
-          warn: jest.fn(),
-          error: jest.fn(),
-        },
+        logger,
       }),
     );
-    return app;
+    return { app, logger };
   }
 
   test("rejects traversal attempts", async () => {
-    const app = buildApp();
+    const { app } = buildApp();
 
     const res = await request(app).get(
       "/images/ALBUM/..%2F..%2Fetc%2Fpasswd",
@@ -53,7 +54,7 @@ describe("images middleware", () => {
     const exported = "20240101T010203000000Z-My Photo (1).jpg";
     await fs.writeFile(path.join(albumDir, exported), "image-bytes");
 
-    const app = buildApp();
+    const { app, logger } = buildApp();
 
     const res = await request(app)
       .get("/images/ALBUM1/20240101T010203000000Z-My%20Photo.jpg")
@@ -66,6 +67,15 @@ describe("images middleware", () => {
 
     expect(res.status).toBe(200);
     expect(res.headers["cache-control"]).toContain("immutable");
+    expect(res.headers).toHaveProperty("etag");
     expect(res.body.toString()).toBe("image-bytes");
+    expect(logger.info).toHaveBeenCalledWith(
+      "images: using fallback filename match",
+      {
+        albumUUID: "ALBUM1",
+        requested: "20240101T010203000000Z-My Photo.jpg",
+        resolved: "20240101T010203000000Z-My Photo (1).jpg",
+      },
+    );
   });
 });

--- a/backend/tests/utils/exported-filename.test.js
+++ b/backend/tests/utils/exported-filename.test.js
@@ -1,0 +1,59 @@
+import path from "path";
+import {
+  buildExportedFilename,
+  parseExportedTimestamp,
+  libraryRelativePath,
+} from "../../utils/exported-filename.js";
+import {
+  getLibraryPathForExportedName,
+  getLibraryDirTemplate,
+} from "../../config/storage-paths.js";
+
+describe("exported filename helpers", () => {
+  afterEach(() => {
+    delete process.env.PF_LIBRARY_DIR_TEMPLATE;
+    delete process.env.PF_LIBRARY_ROOT;
+  });
+
+  it("builds filenames with microsecond precision", () => {
+    const photo = {
+      original_filename: "IMG_0001.HEIC",
+      date: "2024-02-20T18:42:33.123Z",
+    };
+    const exported = buildExportedFilename(photo);
+    expect(exported).toBe("20240220T184233123000Z-IMG_0001.jpg");
+    const parts = parseExportedTimestamp(exported);
+    expect(parts).toMatchObject({
+      year: "2024",
+      month: "02",
+      day: "20",
+      hour: "18",
+      minute: "42",
+      second: "33",
+      microsecond: "123000",
+    });
+  });
+
+  it("derives library directories from templates", () => {
+    const exported = "20240220T184233123000Z-IMG_0001.jpg";
+    const relative = libraryRelativePath(exported, "{created.utc.strftime,%Y/%m/%d}");
+    expect(relative).toBe(path.join("2024", "02", "20"));
+
+    const customRelative = libraryRelativePath(
+      exported,
+      "{created.utc.strftime,%Y/%m/pf-%d}",
+    );
+    expect(customRelative).toBe(path.join("2024", "02", "pf-20"));
+  });
+
+  it("aligns library paths with configured template", () => {
+    process.env.PF_LIBRARY_ROOT = "/tmp/photo-filter-library";
+    process.env.PF_LIBRARY_DIR_TEMPLATE = "{created.utc.strftime,%Y/%j}";
+    const exported = "20240220T184233123000Z-IMG_0001.jpg";
+    const libraryPath = getLibraryPathForExportedName(exported);
+    expect(libraryPath).toBe(
+      path.join("/tmp/photo-filter-library", "2024", "051", exported),
+    );
+    expect(getLibraryDirTemplate()).toBe("{created.utc.strftime,%Y/%j}");
+  });
+});

--- a/backend/utils/clone-file.js
+++ b/backend/utils/clone-file.js
@@ -1,0 +1,152 @@
+import fs from "fs-extra";
+import path from "path";
+
+const BUSY_CODES = new Set(["EBUSY", "ETXTBSY"]);
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sameDevice(srcStat, destStat) {
+  if (!srcStat || !destStat) return false;
+  return srcStat.dev === destStat.dev;
+}
+
+async function statOptional(p) {
+  try {
+    return await fs.stat(p);
+  } catch {
+    return null;
+  }
+}
+
+export async function cloneFile(src, dest, { logger } = {}) {
+  const log = (level, message, extra = {}) => {
+    if (!logger) return;
+    const fn = typeof logger[level] === "function" ? logger[level] : null;
+    if (fn) fn(message, extra);
+  };
+
+  await fs.ensureDir(path.dirname(dest));
+
+  const srcStat = await statOptional(src);
+  if (!srcStat) {
+    const err = new Error(`Source not found for clone: ${src}`);
+    err.code = "ENOENT";
+    throw err;
+  }
+
+  const destParent = path.dirname(dest);
+  const destParentStat = await statOptional(destParent);
+
+  if (await fs.pathExists(dest)) {
+    try {
+      await fs.remove(dest);
+    } catch (err) {
+      log("warn", "cloneFile: failed to remove destination", {
+        src,
+        dest,
+        code: err?.code,
+        errno: err?.errno,
+        message: err?.message,
+      });
+      throw err;
+    }
+  }
+
+  try {
+    await copyWithRetry(() =>
+      fs.copyFile(src, dest, fs.constants.COPYFILE_FICLONE),
+    );
+    return await logMethod(log, src, dest, "clone");
+  } catch (err) {
+    if (err.code !== "ENOTSUP" && err.code !== "EXDEV" && err.errno !== 95) {
+      log("warn", "cloneFile: COPYFILE_FICLONE failed", {
+        src,
+        dest,
+        code: err.code,
+        errno: err.errno,
+      });
+    }
+  }
+
+  if (sameDevice(srcStat, destParentStat)) {
+    try {
+      await copyWithRetry(() => fs.link(src, dest));
+      return await logMethod(log, src, dest, "link");
+    } catch (err) {
+      if (err.code !== "EXDEV") {
+        log("warn", "cloneFile: hard link failed", {
+          src,
+          dest,
+          code: err.code,
+          errno: err.errno,
+        });
+      }
+    }
+  } else {
+    log("warn", "cloneFile: cross-device; falling back to copy", { src, dest });
+  }
+
+  const tempName = `${path.basename(dest)}.tmp-${process.pid}-${
+    Math.random().toString(16).slice(2)
+  }`;
+  const tempPath = path.join(path.dirname(dest), tempName);
+  try {
+    await fs.copyFile(src, tempPath);
+    await fs.chmod(tempPath, srcStat.mode).catch((err) => {
+      log("warn", "cloneFile: failed to chmod temp copy", {
+        src,
+        dest,
+        tempPath,
+        code: err?.code,
+        errno: err?.errno,
+      });
+    });
+    await fs
+      .utimes(tempPath, srcStat.atime, srcStat.mtime)
+      .catch((err) => {
+        log("warn", "cloneFile: failed to preserve timestamps", {
+          src,
+          dest,
+          tempPath,
+          code: err?.code,
+          errno: err?.errno,
+        });
+      });
+    await fs.rename(tempPath, dest);
+  } catch (err) {
+    await fs.remove(tempPath).catch(() => {});
+    throw err;
+  }
+
+  return await logMethod(log, src, dest, "copy");
+}
+
+async function copyWithRetry(fn) {
+  let attempt = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === 0 && BUSY_CODES.has(err?.code)) {
+        attempt += 1;
+        await delay(50);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+async function logMethod(log, src, dest, method) {
+  const size = (await fs.stat(dest)).size;
+  log("info", "cloneFile: materialized image", {
+    src,
+    dest,
+    method,
+    size,
+  });
+  return method;
+}

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -16,6 +16,7 @@
 import fs from "fs-extra";
 import path from "path";
 import { execCommand } from "./exec-command.js";
+import { getLibraryDirTemplate } from "../config/storage-paths.js";
 
 export async function loadUuidsFromFile(filePath) {
   const raw = await fs.readFile(filePath, "utf8").catch(() => "");
@@ -33,20 +34,21 @@ export async function loadUuidsFromFile(filePath) {
  *
  * @param {string} osxphotosPath absolute path to the `osxphotos` binary
  * @param {string} albumUUID     Photos album UUID
- * @param {string} imagesDir     destination directory
+ * @param {string} destinationDir destination directory
  * @param {string} uuidsFile     path to the album’s uuid list file
  * @param {{ logStream?: import("stream").Writable }} [options]
  */
 export async function runOsxphotosExportImages(
   osxphotosPath,
   albumUUID,
-  imagesDir,
+  destinationDir,
   uuidsFile,
   options = {}
 ) {
-  const resolvedUuidsFile = uuidsFile || path.join(imagesDir, "uuids.txt");
+  const resolvedUuidsFile =
+    uuidsFile || path.join(destinationDir, "uuids.txt");
 
-  await fs.ensureDir(imagesDir);
+  await fs.ensureDir(destinationDir);
   if (!(await fs.pathExists(resolvedUuidsFile))) {
     throw new Error(
       `UUID list not found for album ${albumUUID} at ${resolvedUuidsFile}`
@@ -54,7 +56,7 @@ export async function runOsxphotosExportImages(
   }
 
   const uuids = await loadUuidsFromFile(resolvedUuidsFile);
-  const markerPath = path.join(imagesDir, ".skipped-empty");
+  const markerPath = path.join(destinationDir, ".skipped-empty");
 
   const logMessage = (message) => {
     if (
@@ -87,7 +89,7 @@ export async function runOsxphotosExportImages(
 
   const args = [
     "export",
-    imagesDir,
+    destinationDir,
     "--uuid-from-file",
     resolvedUuidsFile,
     "--download-missing",
@@ -103,6 +105,12 @@ export async function runOsxphotosExportImages(
     "--jpeg-ext",
     "jpg",
   ];
+
+  const directoryTemplate =
+    options.directoryTemplate || getLibraryDirTemplate();
+  if (directoryTemplate) {
+    args.push("--directory", directoryTemplate);
+  }
 
   if (
     options.logStream &&

--- a/backend/utils/exported-filename.js
+++ b/backend/utils/exported-filename.js
@@ -1,0 +1,96 @@
+import path from "path";
+import { formatPreciseTimestamp } from "./helpers.js";
+
+const EXPORTED_NAME_REGEX =
+  /^(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})T(?<hour>\d{2})(?<minute>\d{2})(?<second>\d{2})(?<microsecond>\d{6})Z-/;
+const SUPPORTED_DIRECTIVES = new Map(
+  Object.entries({
+    "%Y": "year",
+    "%m": "month",
+    "%d": "day",
+    "%H": "hour",
+    "%M": "minute",
+    "%S": "second",
+    "%f": "microsecond",
+    "%j": "dayOfYear",
+  }),
+);
+
+export function buildExportedFilename(photo) {
+  if (!photo) return null;
+  const originalSource =
+    photo.original_filename || photo.originalFilename || photo.originalName;
+  if (!originalSource) return null;
+  const originalName = path.parse(originalSource).name;
+  if (!originalName) return null;
+
+  const rawDate = photo.date ?? photo.creation_date ?? photo.creationDate;
+  if (!rawDate) return null;
+
+  const timestamp = formatPreciseTimestamp(rawDate);
+  if (!timestamp) return null;
+
+  return `${timestamp}-${originalName}.jpg`;
+}
+
+export function parseExportedTimestamp(exportedName) {
+  if (typeof exportedName !== "string") return null;
+  const match = exportedName.match(EXPORTED_NAME_REGEX);
+  if (!match?.groups) return null;
+  let dayOfYear = null;
+  try {
+    const iso = `${match.groups.year}-${match.groups.month}-${match.groups.day}T${match.groups.hour}:${match.groups.minute}:${match.groups.second}.${match.groups.microsecond}Z`;
+    const date = new Date(iso);
+    if (!Number.isNaN(date.getTime())) {
+      const start = Date.UTC(Number(match.groups.year), 0, 1);
+      const diff = date.getTime() - start;
+      const ordinal = Math.floor(diff / 86_400_000) + 1;
+      dayOfYear = ordinal.toString().padStart(3, "0");
+    }
+  } catch {
+    dayOfYear = null;
+  }
+
+  return {
+    year: match.groups.year,
+    month: match.groups.month,
+    day: match.groups.day,
+    hour: match.groups.hour,
+    minute: match.groups.minute,
+    second: match.groups.second,
+    microsecond: match.groups.microsecond,
+    dayOfYear,
+  };
+}
+
+export function extractStrftimeTemplate(template) {
+  if (!template) return null;
+  const trimmed = template.trim();
+  if (!trimmed) return null;
+  const match = trimmed.match(/\{[^}]*strftime,([^}]+)}/i);
+  if (match) {
+    return match[1];
+  }
+  return trimmed;
+}
+
+export function libraryRelativePath(exportedName, template) {
+  const parts = parseExportedTimestamp(exportedName);
+  if (!parts) return null;
+
+  const strftime = extractStrftimeTemplate(template) ?? "%Y/%m/%d";
+  const replaced = strftime.replace(/%[YmdHMSfj]/g, (directive) => {
+    const key = SUPPORTED_DIRECTIVES.get(directive);
+    const value = key ? parts[key] : null;
+    return value ?? directive;
+  });
+
+  const segments = replaced
+    .split(/[\\/]/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+  if (segments.length === 0) {
+    return path.join(parts.year, parts.month, parts.day);
+  }
+  return path.join(...segments);
+}

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -2,6 +2,7 @@
 
 import fs from "fs-extra";
 import path from "path";
+import pLimit from "p-limit";
 import { runPythonScript } from "./run-python-script.js";
 import {
   loadUuidsFromFile,
@@ -9,6 +10,17 @@ import {
 } from "./export-images.js";
 import { loadStatus, writeStatus, clearStatus } from "./export-status.js";
 import { ensureLegacySymlink } from "./symlinks.js";
+import {
+  getLibraryPathForExportedName,
+  getLibraryRoot,
+} from "../config/storage-paths.js";
+import { buildExportedFilename } from "./exported-filename.js";
+import { cloneFile } from "./clone-file.js";
+
+const CLONE_CONCURRENCY = Math.max(
+  1,
+  Number.parseInt(process.env.PF_CLONE_CONCURRENCY ?? "8", 10),
+);
 
 const inFlight = new Map();
 
@@ -20,6 +32,7 @@ async function prepareAlbumInternal(context) {
     imagesDir,
     legacyImagesDir,
     exportBase,
+    libraryRoot = getLibraryRoot(),
     python,
     pyExport,
     osxphotos,
@@ -29,6 +42,7 @@ async function prepareAlbumInternal(context) {
 
   await fs.ensureDir(albumDir);
   await fs.ensureDir(imagesDir);
+  await fs.ensureDir(libraryRoot);
   await ensureLegacySymlink(imagesDir, legacyImagesDir, { logger: console });
 
   const status = await loadStatus(albumUUID, { exportBase, photosJSON });
@@ -76,7 +90,19 @@ async function prepareAlbumInternal(context) {
   try {
     logMessage(`Starting export for album ${albumUUID}`);
 
-    await fs.remove(uuidsFile).catch(() => {});
+    try {
+      await fs.remove(uuidsFile);
+    } catch (err) {
+      logMessage(
+        `WARN: ${albumUUID} failed to remove uuids file ${uuidsFile}: ${err.message}`,
+      );
+      console.warn(`[prepare-album] ${albumUUID} remove uuids failed`, {
+        path: uuidsFile,
+        code: err?.code,
+        errno: err?.errno,
+        message: err?.message,
+      });
+    }
 
     const { logPath } = await runPythonScript(
       python,
@@ -91,19 +117,45 @@ async function prepareAlbumInternal(context) {
         appendLog: true,
       },
     );
+    const photos = await fs.readJson(photosJSON);
     const uuids = await loadUuidsFromFile(uuidsFile);
     let exportResult = null;
-    if (uuids.length === 0) {
+
+    if (uuids.length === 0 || photos.length === 0) {
       const message = `Album ${albumUUID} empty; skipping osxphotos export`;
       logMessage(message);
       console.log(`[prepare-album] ${message}`);
       await fs.ensureFile(path.join(imagesDir, ".skipped-empty"));
+      try {
+        await fs.remove(path.join(libraryRoot, ".skipped-empty"));
+      } catch (err) {
+        logMessage(
+          `WARN: ${albumUUID} failed to clear library empty marker: ${err.message}`,
+        );
+        console.warn(`[prepare-album] ${albumUUID} clear library marker failed`, {
+          code: err?.code,
+          errno: err?.errno,
+          message: err?.message,
+        });
+      }
     } else {
-      logMessage(`Starting osxphotos export for album ${albumUUID}`);
+      try {
+        await fs.remove(path.join(imagesDir, ".skipped-empty"));
+      } catch (err) {
+        logMessage(
+          `WARN: ${albumUUID} failed to clear skipped marker: ${err.message}`,
+        );
+        console.warn(`[prepare-album] ${albumUUID} clear skipped marker failed`, {
+          code: err?.code,
+          errno: err?.errno,
+          message: err?.message,
+        });
+      }
+      logMessage(`Starting library export for album ${albumUUID}`);
       exportResult = await runOsxphotosExportImages(
         osxphotos,
         albumUUID,
-        imagesDir,
+        libraryRoot,
         uuidsFile,
         {
           logStream,
@@ -111,8 +163,27 @@ async function prepareAlbumInternal(context) {
       );
       if (exportResult?.skippedReason === "empty-album") {
         logMessage(`Album ${albumUUID} empty; skipping osxphotos export`);
+        await fs.ensureFile(path.join(imagesDir, ".skipped-empty"));
       } else {
-        logMessage(`Finished export for album ${albumUUID}`);
+        logMessage(`Finished library export for album ${albumUUID}`);
+        const materialization = await syncAlbumImagesFromLibrary({
+          albumUUID,
+          photos,
+          imagesDir,
+          logger: {
+            info: (message, extra) => logMessage(`${message} ${formatExtra(extra)}`),
+            warn: (message, extra) => logMessage(`WARN: ${message} ${formatExtra(extra)}`),
+          },
+        });
+        if (materialization) {
+          logMessage(
+            `[prepare-album] ${albumUUID} materialization ${formatExtra(materialization)}`,
+          );
+          await writeStatus(albumUUID, exportBase, {
+            materialization,
+            lastMaterializedAt: new Date().toISOString(),
+          });
+        }
       }
     }
     return await writeStatus(albumUUID, exportBase, {
@@ -120,6 +191,7 @@ async function prepareAlbumInternal(context) {
       finishedAt: new Date().toISOString(),
       errorMessage: null,
       logPath: logPath || runningStatus.logPath,
+      exportedCount: exportResult?.exported ?? 0,
     });
   } catch (err) {
     logMessage(`Export failed for album ${albumUUID}: ${err.message}`);
@@ -129,11 +201,19 @@ async function prepareAlbumInternal(context) {
       errorMessage: err.message,
       logPath: runningStatus.logPath,
     });
-    await closeLogStream().catch(() => {});
+    await closeLogStream().catch((err) => {
+      console.warn(`[prepare-album] ${albumUUID} failed to close log stream`, {
+        message: err?.message,
+      });
+    });
     throw err;
   }
   finally {
-    await closeLogStream().catch(() => {});
+    await closeLogStream().catch((err) => {
+      console.warn(`[prepare-album] ${albumUUID} failed to close log stream`, {
+        message: err?.message,
+      });
+    });
   }
 }
 
@@ -153,4 +233,130 @@ export function ensureAlbumPrepared(context) {
     });
   inFlight.set(albumUUID, promise);
   return promise;
+}
+
+function formatExtra(extra) {
+  if (!extra) return "";
+  try {
+    return JSON.stringify(extra);
+  } catch {
+    return String(extra);
+  }
+}
+
+async function syncAlbumImagesFromLibrary({
+  albumUUID,
+  photos,
+  imagesDir,
+  logger = console,
+}) {
+  const expected = new Map();
+  for (const photo of photos) {
+    const exported = buildExportedFilename(photo);
+    if (!exported) continue;
+    expected.set(exported, getLibraryPathForExportedName(exported));
+  }
+
+  const keepNames = new Set(["uuids.txt"]);
+  const counters = { clone: 0, link: 0, copy: 0, missing: 0, errors: 0 };
+  const limit = pLimit(CLONE_CONCURRENCY);
+  const tasks = [];
+
+  for (const [exportedName, libraryPath] of expected) {
+    keepNames.add(exportedName);
+    tasks.push(
+      limit(async () => {
+        try {
+          const resolved = await resolveLibraryCandidate(
+            libraryPath,
+            exportedName,
+          );
+          if (!resolved) {
+            counters.missing += 1;
+            logger.warn?.("Library image missing", {
+              albumUUID,
+              exportedName,
+              libraryPath,
+            });
+            return;
+          }
+
+          const method = await cloneFile(resolved, path.join(imagesDir, exportedName), {
+            logger,
+          });
+          if (typeof counters[method] === "number") {
+            counters[method] += 1;
+          }
+        } catch (err) {
+          counters.errors += 1;
+          logger.warn?.("Failed to materialize image", {
+            albumUUID,
+            exportedName,
+            error: err?.message,
+            code: err?.code,
+          });
+        }
+      }),
+    );
+  }
+
+  await Promise.all(tasks);
+
+  let existing = [];
+  try {
+    existing = await fs.readdir(imagesDir);
+  } catch (err) {
+    logger.warn?.("Failed to list album images", {
+      albumUUID,
+      imagesDir,
+      error: err?.message,
+    });
+  }
+
+  for (const name of existing) {
+    if (keepNames.has(name)) continue;
+    if (name === ".skipped-empty") continue;
+    if (!/\.jpe?g$/i.test(name)) continue;
+    const target = path.join(imagesDir, name);
+    try {
+      await fs.remove(target);
+    } catch (err) {
+      logger.warn?.("Failed to remove stale image", {
+        albumUUID,
+        path: target,
+        error: err?.message,
+      });
+    }
+  }
+
+  return counters;
+}
+
+async function resolveLibraryCandidate(libraryPath, exportedName) {
+  if (await fs.pathExists(libraryPath)) {
+    return libraryPath;
+  }
+
+  const dir = path.dirname(libraryPath);
+  const ext = path.extname(exportedName);
+  const base = path.basename(exportedName, ext);
+
+  const suffixes = buildCollisionSuffixes();
+  for (const suffix of suffixes) {
+    const candidate = path.join(dir, `${base}${suffix}${ext}`);
+    if (await fs.pathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function buildCollisionSuffixes() {
+  const suffixes = [];
+  for (let i = 1; i <= 9; i += 1) {
+    suffixes.push(`-${i}`);
+    suffixes.push(` (${i})`);
+  }
+  return suffixes;
 }


### PR DESCRIPTION
## Summary
- add configurable library roots/templates and shared helpers for deriving exported paths across the backend
- harden album preparation by cloning with bounded concurrency, atomic fallbacks, and richer status logging
- normalize people-by-filename headers, caching, and docs while extending image responses with caching metadata and updating tests

## Testing
- npm test --prefix backend -- --runTestsByPath backend/tests/controllers/api/filename-controller.test.js backend/tests/controllers/api/photos-controller.test.js backend/tests/utils/exported-filename.test.js backend/tests/middleware/images.test.js *(fails: environment lacks venv/python binaries and mocks for album export pipeline)*

------
https://chatgpt.com/codex/tasks/task_e_69078351723c8330ab224c30934a3e05