### PR TITLE
Fix export paths and clone album images

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,5 +44,5 @@ backend/scripts/smoke-people-by-filename.sh "20100208T174405000000Z-005_3A.jpg"
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `PF_LIBRARY_ROOT` | `<PF_LOCAL_ROOT>/library` | Override the shared library location (must point to a local, non-iCloud volume). |
-| `PF_LIBRARY_DIR_TEMPLATE` | `{created.utc.strftime,%Y/%m/%d}` | Directory layout passed to `osxphotos --directory` and used when resolving library paths. |
+| `PF_LIBRARY_DIR_TEMPLATE` | `{created.utc.year}/{created.utc.mm}/{created.utc.dd}` | Directory layout passed to `osxphotos --directory` and used when resolving library paths. Surround with quotes if your shell would otherwise expand braces. |
 | `PF_CLONE_CONCURRENCY` | `8` | Maximum concurrent clone/link/copy operations when materialising album images from the library. |

--- a/backend/config/concurrency.js
+++ b/backend/config/concurrency.js
@@ -1,0 +1,8 @@
+export function getCloneConcurrency() {
+  const raw = process.env.PF_CLONE_CONCURRENCY ?? "8";
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return 1;
+  }
+  return parsed;
+}

--- a/backend/config/storage-paths.js
+++ b/backend/config/storage-paths.js
@@ -46,7 +46,20 @@ const DEFAULT_LOCAL_ROOT = process.env.DEFAULT_LOCAL_ROOT
   ? path.resolve(process.env.DEFAULT_LOCAL_ROOT)
   : "/Users/Shared/photo-filter-local";
 
-export const LIBRARY_DIR_TEMPLATE_DEFAULT = "{created.utc.strftime,%Y/%m/%d}";
+export const LIBRARY_DIR_TEMPLATE_DEFAULT =
+  "{created.utc.year}/{created.utc.mm}/{created.utc.dd}";
+
+function stripEnclosingQuotes(value) {
+  if (!value) return value;
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  const starts = trimmed[0];
+  const ends = trimmed[trimmed.length - 1];
+  if ((starts === '"' && ends === '"') || (starts === "'" && ends === "'")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
 
 export function getLocalRoot() {
   for (const key of ["PF_LOCAL_ROOT", "PF_MEDIA_ROOT"]) {
@@ -81,8 +94,12 @@ export function getLibraryRoot() {
 export function getLibraryDirTemplate() {
   const raw = process.env.PF_LIBRARY_DIR_TEMPLATE;
   if (!raw) return LIBRARY_DIR_TEMPLATE_DEFAULT;
-  const trimmed = raw.trim();
+  const trimmed = stripEnclosingQuotes(raw.trim());
   return trimmed || LIBRARY_DIR_TEMPLATE_DEFAULT;
+}
+
+export function getLibraryExportDbPath() {
+  return path.join(getLibraryRoot(), ".osxphotos_export.db");
 }
 
 export function getLibraryPathForExportedName(exportedName) {

--- a/backend/controllers/api/export-all.js
+++ b/backend/controllers/api/export-all.js
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
+import pLimit from "p-limit";
 import {
   getAlbumImagesDir,
   getExportBase,
@@ -9,6 +10,9 @@ import {
 } from "../../config/storage-paths.js";
 import { buildExportedFilename } from "../../utils/exported-filename.js";
 import { ensureAlbumPrepared } from "../../utils/prepare-album.js";
+import { ensureAlbumImageMaterialized } from "../../utils/materialize-album-image.js";
+import { cloneFile } from "../../utils/clone-file.js";
+import { getCloneConcurrency } from "../../config/concurrency.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -70,19 +74,70 @@ export async function exportAll(req, res) {
     const albumAllDir = path.join(exportBase, "_all");
     await fs.ensureDir(albumAllDir);
 
-    for (const photo of filtered) {
-      if (!photo.exportedFilename) {
-        continue;
-      }
-      const src = path.join(imagesDir, photo.exportedFilename);
-      if (await fs.pathExists(src)) {
-        const dest = path.join(albumAllDir, photo.exportedFilename);
-        await fs.copy(src, dest);
-      }
-    }
+    const limit = pLimit(getCloneConcurrency());
+    const stats = {
+      total: 0,
+      cloned: 0,
+      skipped: 0,
+      missing: 0,
+      errors: 0,
+    };
+
+    await Promise.all(
+      filtered.map((photo) =>
+        limit(async () => {
+          if (!photo.exportedFilename) {
+            return;
+          }
+          stats.total += 1;
+          try {
+            const materialized = await ensureAlbumImageMaterialized({
+              albumUUID,
+              exportedName: photo.exportedFilename,
+              imagesDir,
+              logger: console,
+            });
+            const src = materialized?.path || path.join(imagesDir, photo.exportedFilename);
+            const exists = await fs.pathExists(src);
+            if (!exists) {
+              stats.missing += 1;
+              console.warn("exportAll: source missing", {
+                albumUUID,
+                exportedName: photo.exportedFilename,
+              });
+              return;
+            }
+
+            const dest = path.join(albumAllDir, photo.exportedFilename);
+            if (await fs.pathExists(dest)) {
+              stats.skipped += 1;
+              return;
+            }
+
+            const method = await cloneFile(src, dest, {
+              logger: console,
+              skipIfExists: true,
+            });
+            if (method !== "skip") {
+              stats.cloned += 1;
+            } else {
+              stats.skipped += 1;
+            }
+          } catch (err) {
+            stats.errors += 1;
+            console.warn("exportAll: failed to clone", {
+              albumUUID,
+              exportedName: photo.exportedFilename,
+              error: err?.message,
+            });
+          }
+        }),
+      ),
+    );
 
     return res.json({
       message: `Exported ${filtered.length} photos to ${albumAllDir}`,
+      stats,
     });
   } catch (err) {
     console.error("exportAll error:", err);

--- a/backend/middleware/images.js
+++ b/backend/middleware/images.js
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import path from "path";
 import { getAlbumImagesDir } from "../config/storage-paths.js";
 import { findExportedImageMatch } from "../utils/match-exported-image.js";
+import { ensureAlbumImageMaterialized } from "../utils/materialize-album-image.js";
 
 function isSafeAlbum(albumUUID) {
   return /^[A-Za-z0-9_-]+$/.test(albumUUID);
@@ -15,6 +16,7 @@ function isTraversalAttempt(root, candidate) {
 export function createImagesMiddleware({
   fsClient = fs,
   getImagesDir = getAlbumImagesDir,
+  materializeImage = ensureAlbumImageMaterialized,
   logger = console,
 } = {}) {
   return async function imagesMiddleware(req, res) {
@@ -41,6 +43,17 @@ export function createImagesMiddleware({
       if (exists) {
         await applyCachingHeaders(res, fsClient, candidatePath);
         return res.sendFile(candidatePath, { cacheControl: false });
+      }
+
+      const materialized = await materializeImage({
+        albumUUID,
+        exportedName: requestedName,
+        imagesDir,
+        logger,
+      });
+      if (materialized?.path) {
+        await applyCachingHeaders(res, fsClient, materialized.path);
+        return res.sendFile(materialized.path, { cacheControl: false });
       }
 
       const dirExists = await fsClient.pathExists(imagesDir);

--- a/backend/tests/middleware/images.test.js
+++ b/backend/tests/middleware/images.test.js
@@ -19,7 +19,7 @@ describe("images middleware", () => {
     }
   });
 
-  function buildApp() {
+  function buildApp(overrides = {}) {
     const app = express();
     app.set("etag", "strong");
     const logger = {
@@ -32,6 +32,7 @@ describe("images middleware", () => {
       createImagesMiddleware({
         getImagesDir: (albumUUID) => path.join(tmpDir, albumUUID),
         logger,
+        ...overrides,
       }),
     );
     return { app, logger };
@@ -77,5 +78,37 @@ describe("images middleware", () => {
         resolved: "20240101T010203000000Z-My Photo (1).jpg",
       },
     );
+  });
+
+  test("materializes missing images from library", async () => {
+    const albumDir = path.join(tmpDir, "ALBUM1");
+    const exported = "20240101T010203000000Z-My Photo.jpg";
+    const destPath = path.join(albumDir, exported);
+    const materializeImage = jest.fn(async ({ imagesDir }) => {
+      await fs.ensureDir(imagesDir);
+      await fs.writeFile(destPath, "cloned-image");
+      return { path: destPath, method: "clone" };
+    });
+
+    const { app, logger } = buildApp({ materializeImage });
+
+    const res = await request(app)
+      .get(`/images/ALBUM1/${encodeURIComponent(exported)}`)
+      .buffer(true)
+      .parse((res, callback) => {
+        const chunks = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.toString()).toBe("cloned-image");
+    expect(materializeImage).toHaveBeenCalledWith({
+      albumUUID: "ALBUM1",
+      exportedName: exported,
+      imagesDir: path.join(tmpDir, "ALBUM1"),
+      logger,
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/utils/exported-filename.test.js
+++ b/backend/tests/utils/exported-filename.test.js
@@ -36,19 +36,28 @@ describe("exported filename helpers", () => {
 
   it("derives library directories from templates", () => {
     const exported = "20240220T184233123000Z-IMG_0001.jpg";
-    const relative = libraryRelativePath(exported, "{created.utc.strftime,%Y/%m/%d}");
+    const relative = libraryRelativePath(
+      exported,
+      "{created.utc.strftime,%Y/%m/%d}",
+    );
     expect(relative).toBe(path.join("2024", "02", "20"));
+
+    const placeholderRelative = libraryRelativePath(
+      exported,
+      "{created.utc.year}/{created.utc.mm}/{created.utc.dd}",
+    );
+    expect(placeholderRelative).toBe(path.join("2024", "02", "20"));
 
     const customRelative = libraryRelativePath(
       exported,
-      "{created.utc.strftime,%Y/%m/pf-%d}",
+      "'{created.utc.year}/pf-{created.utc.dd}'",
     );
-    expect(customRelative).toBe(path.join("2024", "02", "pf-20"));
+    expect(customRelative).toBe(path.join("2024", "pf-20"));
   });
 
   it("aligns library paths with configured template", () => {
     process.env.PF_LIBRARY_ROOT = "/tmp/photo-filter-library";
-    process.env.PF_LIBRARY_DIR_TEMPLATE = "{created.utc.strftime,%Y/%j}";
+    process.env.PF_LIBRARY_DIR_TEMPLATE = '"{created.utc.strftime,%Y/%j}"';
     const exported = "20240220T184233123000Z-IMG_0001.jpg";
     const libraryPath = getLibraryPathForExportedName(exported);
     expect(libraryPath).toBe(

--- a/backend/utils/clone-file.js
+++ b/backend/utils/clone-file.js
@@ -20,7 +20,7 @@ async function statOptional(p) {
   }
 }
 
-export async function cloneFile(src, dest, { logger } = {}) {
+export async function cloneFile(src, dest, { logger, skipIfExists = false } = {}) {
   const log = (level, message, extra = {}) => {
     if (!logger) return;
     const fn = typeof logger[level] === "function" ? logger[level] : null;
@@ -28,6 +28,11 @@ export async function cloneFile(src, dest, { logger } = {}) {
   };
 
   await fs.ensureDir(path.dirname(dest));
+
+  if (skipIfExists && (await fs.pathExists(dest))) {
+    log("info", "cloneFile: destination already exists", { src, dest });
+    return "skip";
+  }
 
   const srcStat = await statOptional(src);
   if (!srcStat) {

--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -16,7 +16,10 @@
 import fs from "fs-extra";
 import path from "path";
 import { execCommand } from "./exec-command.js";
-import { getLibraryDirTemplate } from "../config/storage-paths.js";
+import {
+  getLibraryDirTemplate,
+  getLibraryExportDbPath,
+} from "../config/storage-paths.js";
 
 export async function loadUuidsFromFile(filePath) {
   const raw = await fs.readFile(filePath, "utf8").catch(() => "");
@@ -110,6 +113,11 @@ export async function runOsxphotosExportImages(
     options.directoryTemplate || getLibraryDirTemplate();
   if (directoryTemplate) {
     args.push("--directory", directoryTemplate);
+  }
+
+  const exportDbPath = options.exportDbPath || getLibraryExportDbPath();
+  if (exportDbPath) {
+    args.push("--export-db", exportDbPath);
   }
 
   if (

--- a/backend/utils/exported-filename.js
+++ b/backend/utils/exported-filename.js
@@ -16,6 +16,37 @@ const SUPPORTED_DIRECTIVES = new Map(
   }),
 );
 
+const TEMPLATE_TOKEN_MAP = new Map(
+  [
+    "created.utc.year",
+    "created.year",
+    "created.utc.yy",
+    "created.yy",
+  ].map((key) => [key, "year"]),
+);
+
+TEMPLATE_TOKEN_MAP.set("created.utc.mm", "month");
+TEMPLATE_TOKEN_MAP.set("created.mm", "month");
+TEMPLATE_TOKEN_MAP.set("created.utc.month", "month");
+TEMPLATE_TOKEN_MAP.set("created.month", "month");
+TEMPLATE_TOKEN_MAP.set("created.utc.dd", "day");
+TEMPLATE_TOKEN_MAP.set("created.dd", "day");
+TEMPLATE_TOKEN_MAP.set("created.utc.day", "day");
+TEMPLATE_TOKEN_MAP.set("created.day", "day");
+
+function stripTemplateQuotes(value) {
+  if (!value) return value;
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
 export function buildExportedFilename(photo) {
   if (!photo) return null;
   const originalSource =
@@ -65,7 +96,7 @@ export function parseExportedTimestamp(exportedName) {
 
 export function extractStrftimeTemplate(template) {
   if (!template) return null;
-  const trimmed = template.trim();
+  const trimmed = stripTemplateQuotes(template.trim());
   if (!trimmed) return null;
   const match = trimmed.match(/\{[^}]*strftime,([^}]+)}/i);
   if (match) {
@@ -78,19 +109,43 @@ export function libraryRelativePath(exportedName, template) {
   const parts = parseExportedTimestamp(exportedName);
   if (!parts) return null;
 
-  const strftime = extractStrftimeTemplate(template) ?? "%Y/%m/%d";
-  const replaced = strftime.replace(/%[YmdHMSfj]/g, (directive) => {
-    const key = SUPPORTED_DIRECTIVES.get(directive);
-    const value = key ? parts[key] : null;
-    return value ?? directive;
+  const fallback = path.join(parts.year, parts.month, parts.day);
+  if (!template) {
+    return fallback;
+  }
+
+  const cleaned = stripTemplateQuotes(template);
+  if (!cleaned) {
+    return fallback;
+  }
+
+  if (/strftime/i.test(cleaned)) {
+    const strftime = extractStrftimeTemplate(cleaned) ?? "%Y/%m/%d";
+    const replaced = strftime.replace(/%[YmdHMSfj]/g, (directive) => {
+      const key = SUPPORTED_DIRECTIVES.get(directive);
+      const value = key ? parts[key] : null;
+      return value ?? directive;
+    });
+
+    const segments = replaced
+      .split(/[\\/]/)
+      .map((segment) => segment.trim())
+      .filter(Boolean);
+    return segments.length === 0 ? fallback : path.join(...segments);
+  }
+
+  const replaced = cleaned.replace(/\{([^}]+)}/g, (match, body) => {
+    const normalized = body.trim().toLowerCase();
+    const key = TEMPLATE_TOKEN_MAP.get(normalized);
+    if (key && parts[key]) {
+      return parts[key];
+    }
+    return match;
   });
 
   const segments = replaced
     .split(/[\\/]/)
     .map((segment) => segment.trim())
     .filter(Boolean);
-  if (segments.length === 0) {
-    return path.join(parts.year, parts.month, parts.day);
-  }
-  return path.join(...segments);
+  return segments.length === 0 ? fallback : path.join(...segments);
 }

--- a/backend/utils/library-files.js
+++ b/backend/utils/library-files.js
@@ -1,0 +1,36 @@
+import path from "path";
+import fs from "fs-extra";
+
+const COLLISION_SUFFIXES = buildCollisionSuffixes();
+
+export async function resolveLibraryCandidate(libraryPath, exportedName) {
+  if (!libraryPath) {
+    return null;
+  }
+
+  if (await fs.pathExists(libraryPath)) {
+    return libraryPath;
+  }
+
+  const dir = path.dirname(libraryPath);
+  const ext = path.extname(exportedName);
+  const base = path.basename(exportedName, ext);
+
+  for (const suffix of COLLISION_SUFFIXES) {
+    const candidate = path.join(dir, `${base}${suffix}${ext}`);
+    if (await fs.pathExists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function buildCollisionSuffixes() {
+  const suffixes = [];
+  for (let i = 1; i <= 9; i += 1) {
+    suffixes.push(`-${i}`);
+    suffixes.push(` (${i})`);
+  }
+  return suffixes;
+}

--- a/backend/utils/materialize-album-image.js
+++ b/backend/utils/materialize-album-image.js
@@ -1,0 +1,89 @@
+import path from "path";
+import fs from "fs-extra";
+import {
+  getLibraryPathForExportedName,
+  getLibraryRoot,
+} from "../config/storage-paths.js";
+import { resolveLibraryCandidate } from "./library-files.js";
+import { cloneFile } from "./clone-file.js";
+
+const manifestCache = new Map();
+
+export async function ensureAlbumImageMaterialized({
+  albumUUID,
+  exportedName,
+  imagesDir,
+  logger = console,
+}) {
+  if (!exportedName) {
+    return null;
+  }
+
+  const destination = path.join(imagesDir, exportedName);
+  if (await fs.pathExists(destination)) {
+    return { path: destination, method: "exists" };
+  }
+
+  const manifest = await loadManifest(imagesDir);
+  let libraryPath = null;
+  const manifestEntry = manifest?.[exportedName];
+  if (manifestEntry) {
+    libraryPath = path.join(getLibraryRoot(), manifestEntry);
+  }
+  if (!libraryPath) {
+    libraryPath = getLibraryPathForExportedName(exportedName);
+  }
+  if (!libraryPath) {
+    logger.warn?.("materialize-image: no library path", {
+      albumUUID,
+      exportedName,
+    });
+    return null;
+  }
+
+  const resolved = await resolveLibraryCandidate(libraryPath, exportedName);
+  if (!resolved) {
+    logger.warn?.("materialize-image: library source missing", {
+      albumUUID,
+      exportedName,
+      libraryPath,
+    });
+    return null;
+  }
+
+  const method = await cloneFile(resolved, destination, {
+    logger,
+    skipIfExists: true,
+  });
+
+  return { path: destination, method };
+}
+
+async function loadManifest(imagesDir) {
+  const manifestPath = path.join(imagesDir, "manifest.json");
+  let stats;
+  try {
+    stats = await fs.stat(manifestPath);
+  } catch {
+    manifestCache.delete(manifestPath);
+    return null;
+  }
+
+  const cached = manifestCache.get(manifestPath);
+  if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) {
+    return cached.data;
+  }
+
+  try {
+    const data = await fs.readJson(manifestPath);
+    manifestCache.set(manifestPath, {
+      mtimeMs: stats.mtimeMs,
+      size: stats.size,
+      data,
+    });
+    return data;
+  } catch {
+    manifestCache.delete(manifestPath);
+    return null;
+  }
+}

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -21,11 +21,10 @@ import {
 } from "../config/storage-paths.js";
 import { buildExportedFilename } from "./exported-filename.js";
 import { cloneFile } from "./clone-file.js";
+import { getCloneConcurrency } from "../config/concurrency.js";
+import { resolveLibraryCandidate } from "./library-files.js";
 
-const CLONE_CONCURRENCY = Math.max(
-  1,
-  Number.parseInt(process.env.PF_CLONE_CONCURRENCY ?? "8", 10),
-);
+const CLONE_CONCURRENCY = getCloneConcurrency();
 
 const inFlight = new Map();
 
@@ -192,9 +191,12 @@ async function prepareAlbumInternal(context) {
           albumUUID,
           photos,
           imagesDir,
+          libraryRoot,
           logger: {
-            info: (message, extra) => logMessage(`${message} ${formatExtra(extra)}`),
-            warn: (message, extra) => logMessage(`WARN: ${message} ${formatExtra(extra)}`),
+            info: (message, extra) =>
+              logMessage(`${message} ${formatExtra(extra)}`),
+            warn: (message, extra) =>
+              logMessage(`WARN: ${message} ${formatExtra(extra)}`),
           },
         });
         if (materialization) {
@@ -325,6 +327,7 @@ async function syncAlbumImagesFromLibrary({
   albumUUID,
   photos,
   imagesDir,
+  libraryRoot = getLibraryRoot(),
   logger = console,
 }) {
   const expected = new Map();
@@ -338,9 +341,13 @@ async function syncAlbumImagesFromLibrary({
   const counters = { clone: 0, link: 0, copy: 0, missing: 0, errors: 0 };
   const limit = pLimit(CLONE_CONCURRENCY);
   const tasks = [];
+  const manifestEntries = new Map();
 
   for (const [exportedName, libraryPath] of expected) {
     keepNames.add(exportedName);
+    const relative = path.relative(libraryRoot, libraryPath);
+    const manifestValue = relative ? toPosix(relative) : exportedName;
+    manifestEntries.set(exportedName, manifestValue);
     tasks.push(
       limit(async () => {
         try {
@@ -358,9 +365,14 @@ async function syncAlbumImagesFromLibrary({
             return;
           }
 
-          const method = await cloneFile(resolved, path.join(imagesDir, exportedName), {
-            logger,
-          });
+          const method = await cloneFile(
+            resolved,
+            path.join(imagesDir, exportedName),
+            {
+              logger,
+              skipIfExists: true,
+            },
+          );
           if (typeof counters[method] === "number") {
             counters[method] += 1;
           }
@@ -379,6 +391,8 @@ async function syncAlbumImagesFromLibrary({
 
   await Promise.all(tasks);
 
+  await writeManifest(imagesDir, manifestEntries, logger, albumUUID);
+
   let existing = [];
   try {
     existing = await fs.readdir(imagesDir);
@@ -393,6 +407,7 @@ async function syncAlbumImagesFromLibrary({
   for (const name of existing) {
     if (keepNames.has(name)) continue;
     if (name === ".skipped-empty") continue;
+    if (name === "manifest.json") continue;
     if (!/\.jpe?g$/i.test(name)) continue;
     const target = path.join(imagesDir, name);
     try {
@@ -409,31 +424,35 @@ async function syncAlbumImagesFromLibrary({
   return counters;
 }
 
-async function resolveLibraryCandidate(libraryPath, exportedName) {
-  if (await fs.pathExists(libraryPath)) {
-    return libraryPath;
+async function writeManifest(imagesDir, manifestEntries, logger, albumUUID) {
+  const manifestPath = path.join(imagesDir, "manifest.json");
+  if (!manifestEntries || manifestEntries.size === 0) {
+    await fs.remove(manifestPath).catch(() => {});
+    return;
   }
 
-  const dir = path.dirname(libraryPath);
-  const ext = path.extname(exportedName);
-  const base = path.basename(exportedName, ext);
-
-  const suffixes = buildCollisionSuffixes();
-  for (const suffix of suffixes) {
-    const candidate = path.join(dir, `${base}${suffix}${ext}`);
-    if (await fs.pathExists(candidate)) {
-      return candidate;
-    }
+  const ordered = {};
+  for (const name of Array.from(manifestEntries.keys()).sort()) {
+    ordered[name] = manifestEntries.get(name);
   }
 
-  return null;
+  try {
+    await fs.writeJson(manifestPath, ordered, { spaces: 2 });
+    logger.info?.("prepare-album: wrote manifest", {
+      albumUUID,
+      manifestPath,
+      entries: manifestEntries.size,
+    });
+  } catch (err) {
+    logger.warn?.("prepare-album: failed to write manifest", {
+      albumUUID,
+      manifestPath,
+      error: err?.message,
+    });
+  }
 }
 
-function buildCollisionSuffixes() {
-  const suffixes = [];
-  for (let i = 1; i <= 9; i += 1) {
-    suffixes.push(`-${i}`);
-    suffixes.push(` (${i})`);
-  }
-  return suffixes;
+function toPosix(value) {
+  if (!value) return value;
+  return value.split(path.sep).join(path.posix.sep);
 }


### PR DESCRIPTION
## Summary
- ensure osxphotos exports into nested YYYY/MM/DD folders via a new default directory template and stable export database path
- materialize album images and per-album exports via APFS clones that consult a manifest, clone lazily on image requests, and fall back to the library when needed
- harden export tooling with manifest generation, concurrency controls, idempotent clone helpers, and updated middleware/tests

## Testing
- `cd backend && npm test` *(fails: Jest is not installed in this environment and npm install cannot complete)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691525e374b08330a5c8d93a10e763cc)