### PR TITLE
Fix osxphotos export flag handling

### DIFF
--- a/backend/utils/export-images.js
+++ b/backend/utils/export-images.js
@@ -117,7 +117,10 @@ export async function runOsxphotosExportImages(
 
   const exportDbPath = options.exportDbPath || getLibraryExportDbPath();
   if (exportDbPath) {
-    args.push("--export-db", exportDbPath);
+    // osxphotos expects `--exportdb` (no hyphen). Allow overriding in case we
+    // need to support future CLI changes while keeping compatibility.
+    const exportDbFlag = process.env.PF_OSXPHOTOS_EXPORTDB_FLAG || "--exportdb";
+    args.push(exportDbFlag, exportDbPath);
   }
 
   if (


### PR DESCRIPTION
## Summary
- default the osxphotos export DB flag to `--exportdb` and allow overriding it via `PF_OSXPHOTOS_EXPORTDB_FLAG`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69153670b1108330b4c12c4740223edf)