### PR TITLE
Fix people lookup API to stream local metadata

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,10 +18,9 @@ The backend builds a filename → UUID index from the system Photos library:
 ## GET /api/people/by-filename/:filename
 
 - `:filename` — URL-encoded exported basename (e.g. `20100208T174405000000Z-005_3A.jpg`).
-- **200**: `{ "data": ["Alice", "Bob"] }`
+- **200**: `{ "filename": "...", "people": ["Alice", "Bob"] }` (unknown filenames still return HTTP 200 with `people: []`).
 - **400**: `{ "errors": [{ "detail": "Filename is required" }] }`
 - **400**: `{ "errors": [{ "detail": "Invalid filename" }] }`
-- **404**: `{ "errors": [{ "detail": "Photo not found" }] }`
 - **500**: `{ "errors": [{ "detail": "Internal Server Error" }] }`
 
 Notes:

--- a/backend/controllers/api/filename-controller.js
+++ b/backend/controllers/api/filename-controller.js
@@ -93,9 +93,7 @@ export async function getPeopleByFilename(req, res) {
       if (cachedMiss.reason) {
         res.set("X-PF-Miss-Reason", cachedMiss.reason);
       }
-      return res
-        .status(404)
-        .json({ errors: [{ detail: "Photo not found" }] });
+      return respondWithEmptyPeople(res, filename);
     }
 
     const albumsDir = path.join(getLocalRoot(), "albums");
@@ -104,9 +102,7 @@ export async function getPeopleByFilename(req, res) {
       cacheMiss(filename, "uninitialized");
       res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
       res.set("X-PF-Miss-Reason", "uninitialized");
-      return res
-        .status(404)
-        .json({ errors: [{ detail: "Photo not found" }] });
+      return respondWithEmptyPeople(res, filename);
     }
 
     let albumUUID = getCachedAlbumUUID(filename);
@@ -119,9 +115,7 @@ export async function getPeopleByFilename(req, res) {
         if (lookupResult?.missReason) {
           res.set("X-PF-Miss-Reason", lookupResult.missReason);
         }
-        return res
-          .status(404)
-          .json({ errors: [{ detail: "Photo not found" }] });
+        return respondWithEmptyPeople(res, filename);
       }
       albumUUID = lookupResult.match.uuid;
       resolveSource = lookupResult.match.source;
@@ -132,10 +126,16 @@ export async function getPeopleByFilename(req, res) {
     const cachedPersons = getCachedPersons(cacheKey);
     if (cachedPersons) {
       res.set("X-PF-Resolve", RESOLVE_SOURCES.CACHE);
-      return res.json({ data: cachedPersons });
+      return res.json({ filename, people: cachedPersons });
     }
 
-    const photosPath = path.join(albumsDir, albumUUID, "photos.json");
+    const photosPath = await getAlbumPhotosJsonPath(albumsDir, albumUUID);
+    if (!photosPath) {
+      cacheMiss(filename, RESOLVE_SOURCES.JSON);
+      res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
+      res.set("X-PF-Miss-Reason", RESOLVE_SOURCES.JSON);
+      return respondWithEmptyPeople(res, filename);
+    }
     const { persons, source } = await runWithAlbumLock(albumUUID, async () => {
       const inLockCached = getCachedPersons(cacheKey);
       if (inLockCached) {
@@ -155,12 +155,12 @@ export async function getPeopleByFilename(req, res) {
       cacheMiss(filename, RESOLVE_SOURCES.JSON);
       res.set("X-PF-Resolve", RESOLVE_SOURCES.MISS);
       res.set("X-PF-Miss-Reason", RESOLVE_SOURCES.JSON);
-      return res.status(404).json({ errors: [{ detail: "Photo not found" }] });
+      return respondWithEmptyPeople(res, filename);
     }
 
     clearMiss(filename);
     res.set("X-PF-Resolve", source ?? resolveSource ?? RESOLVE_SOURCES.JSON);
-    return res.json({ data: persons });
+    return res.json({ filename, people: persons });
   } catch (error) {
     console.error("Error looking up persons by filename:", error);
     res.set("X-PF-Resolve", RESOLVE_SOURCES.ERROR);
@@ -168,6 +168,10 @@ export async function getPeopleByFilename(req, res) {
       .status(500)
       .json({ errors: [{ detail: "Internal Server Error" }] });
   }
+}
+
+function respondWithEmptyPeople(res, filename) {
+  return res.json({ filename, people: [] });
 }
 
 function sanitizeFilename(input) {
@@ -271,6 +275,18 @@ function clearMiss(name) {
   MISS_CACHE.delete(name);
 }
 
+async function getAlbumPhotosJsonPath(albumsDir, albumUUID) {
+  const imagesPath = path.join(albumsDir, albumUUID, "images", "photos.json");
+  if (await fs.pathExists(imagesPath)) {
+    return imagesPath;
+  }
+  const legacyPath = path.join(albumsDir, albumUUID, "photos.json");
+  if (await fs.pathExists(legacyPath)) {
+    return legacyPath;
+  }
+  return null;
+}
+
 async function runWithAlbumLock(albumUUID, fn) {
   const previous = ALBUM_LOCKS.get(albumUUID) ?? Promise.resolve();
   const runPromise = previous.then(() => fn());
@@ -311,8 +327,8 @@ async function findAlbumUUIDByFilename(albumsDir, filename) {
   }
 
   for (const entry of directories) {
-    const photosPath = path.join(albumsDir, entry.name, "photos.json");
-    if (!(await fs.pathExists(photosPath))) {
+    const photosPath = await getAlbumPhotosJsonPath(albumsDir, entry.name);
+    if (!photosPath) {
       continue;
     }
     missReason = RESOLVE_SOURCES.JSON;

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -15,7 +15,7 @@ paths:
           description: URL-encoded exported name (e.g. 20221201T174242329834Z-IMG_5899.jpg)
       responses:
         "200":
-          description: OK
+          description: OK (returns an empty `people` array if the filename cannot be resolved)
           headers:
             X-PF-Resolve:
               $ref: "#/components/headers/XPFResolve"
@@ -27,8 +27,6 @@ paths:
                 $ref: "#/components/schemas/PeopleByFilenameResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
   /api/people/by-filename:
@@ -45,8 +43,6 @@ paths:
           $ref: "#/paths/~1api~1people~1by-filename~1{filename}/get/responses/200"
         "400":
           $ref: "#/components/responses/BadRequest"
-        "404":
-          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 components:
@@ -65,9 +61,16 @@ components:
             $ref: "#/components/schemas/ErrorDetail"
     PeopleByFilenameResponse:
       type: object
+      required:
+        - filename
+        - people
       properties:
-        data:
+        filename:
+          type: string
+          description: Normalized exported basename that was looked up.
+        people:
           type: array
+          description: Sorted list of detected person names (empty when no metadata is available).
           items:
             type: string
   responses:

--- a/backend/docs/people-by-filename.md
+++ b/backend/docs/people-by-filename.md
@@ -11,10 +11,10 @@ Both routes expect URL-encoded filenames. The server decodes path and query para
 
 ## Responses
 
-- **200 OK** – `{ "data": ["Alice", "Bob"] }`
+- **200 OK** – `{ "filename": "20221201...jpg", "people": ["Alice", "Bob"] }`
+  - Unknown filenames still return HTTP 200 with `people: []` so downstream callers are not forced to treat missing metadata as an error.
 - **400 Bad Request** – `{ "errors": [{ "detail": "Filename is required" }] }`
 - **400 Bad Request** – `{ "errors": [{ "detail": "Invalid filename" }] }`
-- **404 Not Found** – `{ "errors": [{ "detail": "Photo not found" }] }`
 - **500 Internal Server Error** – `{ "errors": [{ "detail": "Internal Server Error" }] }`
 
 All `/api/*` responses are JSON and include `Content-Type: application/json`.
@@ -23,7 +23,7 @@ All `/api/*` responses are JSON and include `Content-Type: application/json`.
 
 - During long exports the physical image may not exist yet. The controller falls back to streaming each album’s `photos.json` to rebuild the exported filename and still resolve people.
 - Person names come exclusively from Apple Photos metadata (`persons`, `persons_full`, `face_names`, `faceInfo[].name`). Scene labels such as “Outdoor” or “Building” are excluded.
-- Responses include an `X-PF-Resolve` header describing where the result came from (`cache`, `disk`, `json`, `miss`, `invalid`, or `error`). On `404 Not Found` the response also includes `X-PF-Miss-Reason` to indicate which lookup path failed (`cache`, `disk`, `json`, or `uninitialized`).
+- Responses include an `X-PF-Resolve` header describing where the result came from (`cache`, `disk`, `json`, `miss`, `invalid`, or `error`). On cache misses the response also includes `X-PF-Miss-Reason` to indicate which lookup path failed (`cache`, `disk`, `json`, or `uninitialized`).
 - The controller streams `photos.json` to keep memory use bounded and relies on lightweight caches, per-album locks, and a short-lived negative cache for misses.
 - Cache TTLs and sizes can be tuned with the `PF_FILENAME_CACHE_TTL_MS`, `PF_FILENAME_CACHE_MAX`, `PF_PERSONS_CACHE_TTL_MS`, and `PF_PERSONS_CACHE_MAX` environment variables.
 - Run `./scripts/smoke-people-by-filename.sh "<filename>"` to exercise both path and query variants locally.
@@ -43,4 +43,4 @@ curl -sS -H 'Accept: application/json' \
   "http://localhost:3000/api/people/by-filename?filename=$ENC" | jq .
 ```
 
-Expect `{ "data": [...] }` when the photo exists and `{ "errors": [{ "detail": "Photo not found" }] }` when it does not.
+Expect `{ "filename": "...", "people": [...] }` when the photo exists and `{ "filename": "...", "people": [] }` when it does not.

--- a/backend/tests/api.people-by-filename.test.js
+++ b/backend/tests/api.people-by-filename.test.js
@@ -60,11 +60,12 @@ describe("people-by-filename endpoint", () => {
     expect(first.status).toBe(200);
     expect(first.type).toMatch(/application\/json/);
     expect(["disk", "json"]).toContain(first.headers["x-pf-resolve"]);
-    expect(first.body.data).toEqual(
+    expect(first.body.filename).toBe(exportedDisk);
+    expect(first.body.people).toEqual(
       ["Alice", "Bob", "Carol"].sort((a, b) => a.localeCompare(b)),
     );
-    expect(first.body.data).not.toContain("Outdoor");
-    expect(first.body.data).not.toContain("Building");
+    expect(first.body.people).not.toContain("Outdoor");
+    expect(first.body.people).not.toContain("Building");
 
     const second = await request(app)
       .get(`/api/people/by-filename/${encodeURIComponent(exportedDisk)}`)
@@ -72,7 +73,7 @@ describe("people-by-filename endpoint", () => {
 
     expect(second.status).toBe(200);
     expect(second.headers["x-pf-resolve"]).toBe("cache");
-    expect(second.body.data).toEqual(first.body.data);
+    expect(second.body.people).toEqual(first.body.people);
   });
 
   it("supports the query variant with encoded characters", async () => {
@@ -87,7 +88,8 @@ describe("people-by-filename endpoint", () => {
 
     expect(res.status).toBe(200);
     expect(["disk", "json"]).toContain(res.headers["x-pf-resolve"]);
-    expect(res.body.data).toEqual(expectedNames);
+    expect(res.body.filename).toBe(exportedUnicode);
+    expect(res.body.people).toEqual(expectedNames);
   });
 
   it("serves the legacy alias path", async () => {
@@ -110,7 +112,8 @@ describe("people-by-filename endpoint", () => {
 
     expect(res.status).toBe(200);
     expect(["disk", "json"]).toContain(res.headers["x-pf-resolve"]);
-    expect(res.body.data).toEqual(expected);
+    expect(res.body.filename).toBe(exportedJsonOnly);
+    expect(res.body.people).toEqual(expected);
   });
 
   it("returns 400 for missing filename in query variant", async () => {
@@ -138,14 +141,16 @@ describe("people-by-filename endpoint", () => {
     const first = await request(app)
       .get(`/api/people/by-filename/${missing}`)
       .set("Accept", "application/json");
-    expect(first.status).toBe(404);
+    expect(first.status).toBe(200);
     expect(first.headers["x-pf-resolve"]).toBe("miss");
+    expect(first.body).toEqual({ filename: missing, people: [] });
 
     const second = await request(app)
       .get(`/api/people/by-filename/${missing}`)
       .set("Accept", "application/json");
-    expect(second.status).toBe(404);
+    expect(second.status).toBe(200);
     expect(second.headers["x-pf-resolve"]).toBe("miss");
+    expect(second.body).toEqual({ filename: missing, people: [] });
   });
 
   it("handles concurrent requests without deadlock", async () => {
@@ -164,8 +169,8 @@ describe("people-by-filename endpoint", () => {
 
     expect(a.status).toBe(200);
     expect(b.status).toBe(200);
-    expect(a.body.data).toEqual(payload);
-    expect(b.body.data).toEqual(payload);
+    expect(a.body.people).toEqual(payload);
+    expect(b.body.people).toEqual(payload);
     const headerValues = [a.headers["x-pf-resolve"], b.headers["x-pf-resolve"]];
     headerValues.forEach((value) =>
       expect(["cache", "json", "disk"]).toContain(value),

--- a/backend/tests/controllers/api/filename-controller.test.js
+++ b/backend/tests/controllers/api/filename-controller.test.js
@@ -67,6 +67,9 @@ describe("getPeopleByFilename", () => {
       if (targetPath.includes(path.join("images", exported))) {
         return true;
       }
+      if (targetPath.endsWith(path.join("album1", "images", "photos.json"))) {
+        return true;
+      }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
         return true;
       }
@@ -103,7 +106,8 @@ describe("getPeopleByFilename", () => {
     expect(res.statusCode).toBe(200);
     expect(["disk", "cache"]).toContain(res.getHeader("X-PF-Resolve"));
     const data = res._getJSONData();
-    expect(data.data).toEqual(["Alice", "Bob"]);
+    expect(data.filename).toBe(exported);
+    expect(data.people).toEqual(["Alice", "Bob"]);
     expect(stream.destroy).toHaveBeenCalled();
   });
 
@@ -121,6 +125,9 @@ describe("getPeopleByFilename", () => {
       }
       if (targetPath.includes(path.join("images", exported))) {
         return false;
+      }
+      if (targetPath.endsWith(path.join("album1", "images", "photos.json"))) {
+        return true;
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
         return true;
@@ -158,7 +165,8 @@ describe("getPeopleByFilename", () => {
     expect(res.statusCode).toBe(200);
     expect(res.getHeader("X-PF-Resolve")).toBe("json");
     const data = res._getJSONData();
-    expect(data.data).toEqual(["Alice", "Bob"]);
+    expect(data.filename).toBe(exported);
+    expect(data.people).toEqual(["Alice", "Bob"]);
     expect(stream.destroy).toHaveBeenCalled();
   });
 
@@ -175,6 +183,9 @@ describe("getPeopleByFilename", () => {
         return true;
       }
       if (targetPath.includes(path.join("images", exported))) {
+        return true;
+      }
+      if (targetPath.endsWith(path.join("album1", "images", "photos.json"))) {
         return true;
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
@@ -212,15 +223,18 @@ describe("getPeopleByFilename", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.getHeader("X-PF-Resolve")).toBe("disk");
-    expect(res._getJSONData().data).toEqual(["Alice", "Bob"]);
+    expect(res._getJSONData()).toEqual({ filename: exported, people: ["Alice", "Bob"] });
   });
 
-  it("returns 404 when no photo matches", async () => {
+  it("returns empty metadata when no photo matches", async () => {
     const req = httpMocks.createRequest({ params: { filename: "notfound.jpg" } });
     const res = httpMocks.createResponse();
 
     jest.spyOn(fs, "pathExists").mockImplementation(async (targetPath) => {
       if (targetPath === path.join(localRoot, "albums")) {
+        return true;
+      }
+      if (targetPath.endsWith(path.join("album1", "images", "photos.json"))) {
         return true;
       }
       if (targetPath.endsWith(path.join("album1", "photos.json"))) {
@@ -245,9 +259,10 @@ describe("getPeopleByFilename", () => {
 
     await getPeopleByFilename(req, res);
 
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(200);
     expect(res.getHeader("X-PF-Resolve")).toBe("miss");
     expect(res.getHeader("X-PF-Miss-Reason")).toBe("json");
+    expect(res._getJSONData()).toEqual({ filename: "notfound.jpg", people: [] });
     expect(stream.destroy).toHaveBeenCalled();
   });
 

--- a/docs/API_ENDPOINTS.md
+++ b/docs/API_ENDPOINTS.md
@@ -212,9 +212,8 @@ These endpoints resolve people detected in a photo when only the exported filena
 
 The backend normalises and validates the filename, searches cached mappings, and scans album metadata as needed. Responses:
 
-- Success: HTTP 200 with `{ "data": ["Alice", "Bob"] }`. The `X-PF-Resolve` header reveals whether the value came from cache, disk, or JSON scanning.
+- Success: HTTP 200 with `{ "filename": "20221201...jpg", "people": ["Alice", "Bob"] }`. The `X-PF-Resolve` header reveals whether the value came from cache, disk, or JSON scanning. Unknown filenames return `{ "filename": "...", "people": [] }` with `X-PF-Resolve: miss` so clients do not treat them as transport failures.
 - Invalid or missing filename: HTTP 400 with `X-PF-Resolve: invalid`.
-- Filename not present in any album: HTTP 404 with `X-PF-Resolve: miss`. `X-PF-Miss-Reason` describes the miss (`uninitialized`, `json`, etc.).
 - Errors: HTTP 500 with `X-PF-Resolve: error`.
 
 _Source: [`backend/controllers/api/filename-controller.js`](../backend/controllers/api/filename-controller.js), [`backend/app.js`](../backend/app.js)_


### PR DESCRIPTION
## Summary
- update the filename lookup controller so it reads the per-album `images/photos.json` files, falls back to the legacy layout, and always returns `{ filename, people }` (empty arrays for misses)
- refresh the controller + API tests to cover the new response contract and cache-miss handling
- document the adjusted contract in the README, API endpoints guide, and OpenAPI spec

## Testing
- not run (backend npm install fails on this Linux container because the osx-tag dependency needs macOS frameworks)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163dee28508330ac4dda26b5c33332)