### PR TITLE
Add library-wide people route and people index exporter

### DIFF
--- a/backend/controllers/api/albums-controller.js
+++ b/backend/controllers/api/albums-controller.js
@@ -11,6 +11,7 @@ import {
   readExportStatus,
   readJsonWithRetry,
 } from "../../utils/albums-store.js";
+import { slugifyName } from "../../utils/slugify-name.js";
 
 const PersonSerializer = new Serializer("person", {
   id: "id",
@@ -179,10 +180,3 @@ export const getAlbumById = async (req, res) => {
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
   }
 };
-
-function slugifyName(name) {
-  return name
-    .toLowerCase()
-    .replace(/[\s+]/g, "-")
-    .replace(/[^a-z0-9-]/g, "");
-}

--- a/backend/controllers/api/people-controller.js
+++ b/backend/controllers/api/people-controller.js
@@ -3,10 +3,13 @@
 import path from "path";
 import fs from "fs-extra";
 import { fileURLToPath } from "url";
-import { runPythonScript } from "../../utils/run-python-script.js";
-import { execCommand } from "../../utils/exec-command.js";
 import { Serializer } from "jsonapi-serializer";
 import { getNestedProperty } from "../../utils/helpers.js";
+import {
+  ensurePeopleIndexUpToDate,
+  getPeopleSummary,
+} from "../../utils/people-index.js";
+import { slugifyName } from "../../utils/slugify-name.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,6 +30,20 @@ const PhotoSerializer = new Serializer("photo", {
       type: "album",
     },
   },
+  pluralizeType: false,
+});
+
+const PersonSerializer = new Serializer("person", {
+  id: "id",
+  attributes: [
+    "name",
+    "photoCount",
+    "earliestPhotoAt",
+    "latestPhotoAt",
+    "medianPhotoAt",
+    "heroUuid",
+  ],
+  keyForAttribute: "camelCase",
   pluralizeType: false,
 });
 
@@ -136,5 +153,32 @@ export const getPhotosByPerson = async (req, res) => {
   } catch (error) {
     console.error("Error fetching photos for person:", error);
     res.status(500).json({ errors: [{ detail: "Internal Server Error" }] });
+  }
+};
+
+export const getLibraryPeople = async (req, res) => {
+  try {
+    const sort = req.query.sort || "medianPhotoAt";
+    const order = req.query.order || "asc";
+
+    await ensurePeopleIndexUpToDate();
+    const people = await getPeopleSummary({ sort, order });
+
+    const mapped = people.map((person) => ({
+      ...person,
+      id: slugifyName(person.name),
+    }));
+
+    const payload = PersonSerializer.serialize(mapped);
+
+    return res.json({
+      ...payload,
+      meta: { sort, order },
+    });
+  } catch (error) {
+    console.error("Error fetching library people:", error);
+    return res.status(500).json({
+      errors: [{ detail: "Internal Server Error" }],
+    });
   }
 };

--- a/backend/controllers/api/photos-controller.js
+++ b/backend/controllers/api/photos-controller.js
@@ -14,6 +14,7 @@ import {
   formatPreciseTimestamp,
   getNestedProperty,
 } from "../../utils/helpers.js";
+import { slugifyName } from "../../utils/slugify-name.js";
 import { Serializer } from "jsonapi-serializer";
 import {
   getAlbumImagesDir,
@@ -192,7 +193,7 @@ export const getPhotosByAlbumData = async (req, res) => {
       p.persons = Array.isArray(p.persons) ? p.persons : [];
 
       p.personsData = p.persons.map((name) => {
-        const slug = slugify(name);
+        const slug = slugifyName(name);
         if (!personsMap.has(slug)) personsMap.set(slug, { id: slug, name });
         return { type: "person", id: slug };
       });
@@ -313,10 +314,3 @@ export const prepareAlbumForExport = async (req, res) => {
   }
 };
 
-/* ---------- util ---------- */
-function slugify(str) {
-  return str
-    .toLowerCase()
-    .replace(/[\s+]/g, "-")
-    .replace(/[^a-z0-9-]/g, "");
-}

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -21,6 +21,7 @@ import {
 import {
   getPeopleInAlbum,
   getPhotosByPerson,
+  getLibraryPeople,
 } from "../controllers/api/people-controller.js";
 import { ensureAlbumPrepared } from "../utils/prepare-album.js";
 
@@ -46,6 +47,7 @@ apiRouter.post("/albums/:albumUUID/prepare", prepareAlbumForExport);
 apiRouter.get("/albums/:albumUUID/persons", getPeopleInAlbum);
 apiRouter.get("/albums/:albumUUID/person/:personName", getPhotosByPerson);
 apiRouter.get("/photos/by-filename/:filename/persons", getPeopleByFilename);
+apiRouter.get("/library/people", getLibraryPeople);
 
 // People-by-filename route for exported filenames
 apiRouter.get("/people/by-filename/:filename", getPeopleByFilename);

--- a/backend/scripts/export_people_index.py
+++ b/backend/scripts/export_people_index.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# ./scripts/export_people_index.py
+
+#!/usr/bin/env python3
+# ./scripts/export_people_index.py
+
+import argparse
+import json
+from datetime import timezone
+from pathlib import Path
+
+import osxphotos
+
+
+def isoformat_utc(dt):
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def build_people_index(db):
+    people = {}
+
+    for photo in db.photos():
+        date = getattr(photo, "date", None)
+        if not date:
+            continue
+
+        persons = getattr(photo, "persons", None) or []
+        uuid = getattr(photo, "uuid", None)
+
+        for person_name in persons:
+            bucket = people.setdefault(person_name, [])
+            bucket.append((date, uuid))
+
+    summaries = []
+
+    for name, entries in people.items():
+        if not entries:
+            continue
+
+        sorted_entries = sorted(entries, key=lambda pair: pair[0])
+
+        n = len(sorted_entries)
+        median_index = n // 2
+        median_entry = sorted_entries[median_index]
+
+        summaries.append(
+            {
+                "id": f"person:{name}",
+                "name": name,
+                "photoCount": n,
+                "earliestPhotoAt": isoformat_utc(sorted_entries[0][0]),
+                "latestPhotoAt": isoformat_utc(sorted_entries[-1][0]),
+                "medianPhotoAt": isoformat_utc(median_entry[0]),
+                "heroUuid": median_entry[1],
+            }
+        )
+
+    return summaries
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export library-wide people index")
+    parser.add_argument("--db", help="Path to a specific Photos library", default=None)
+    parser.add_argument("--out", "--output", required=True, dest="out")
+    args = parser.parse_args()
+
+    db = osxphotos.PhotosDB(dbfile=args.db) if args.db else osxphotos.PhotosDB()
+
+    summaries = build_people_index(db)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        json.dump(summaries, fh, ensure_ascii=False, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/testdata/library/people-index.json
+++ b/backend/testdata/library/people-index.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "person:alice",
+    "name": "Alice",
+    "photoCount": 3,
+    "earliestPhotoAt": "2020-01-01T00:00:00Z",
+    "latestPhotoAt": "2020-01-03T00:00:00Z",
+    "medianPhotoAt": "2020-01-02T00:00:00Z",
+    "heroUuid": "hero-a"
+  },
+  {
+    "id": "person:bob",
+    "name": "Bob",
+    "photoCount": 2,
+    "earliestPhotoAt": "2021-01-01T00:00:00Z",
+    "latestPhotoAt": "2021-01-02T00:00:00Z",
+    "medianPhotoAt": "2021-01-01T12:00:00Z",
+    "heroUuid": "hero-b"
+  },
+  {
+    "id": "person:carol",
+    "name": "Carol",
+    "photoCount": 4,
+    "earliestPhotoAt": "2019-05-01T00:00:00Z",
+    "latestPhotoAt": "2019-05-04T00:00:00Z",
+    "medianPhotoAt": "2019-05-02T00:00:00Z",
+    "heroUuid": "hero-c"
+  }
+]

--- a/backend/tests/api.people-library.test.js
+++ b/backend/tests/api.people-library.test.js
@@ -1,0 +1,62 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "fs-extra";
+import request from "supertest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fixturesDir = path.join(__dirname, "..", "testdata");
+const dataDir = path.join(__dirname, "..", "data");
+const peopleFixture = path.join(fixturesDir, "library", "people-index.json");
+
+async function setupFixtureData() {
+  await fs.remove(dataDir);
+  await fs.ensureDir(path.join(dataDir, "library"));
+  await fs.copy(peopleFixture, path.join(dataDir, "library", "people-index.json"));
+}
+
+describe("GET /api/library/people", () => {
+  beforeAll(async () => {
+    await setupFixtureData();
+  });
+
+  afterAll(async () => {
+    await fs.remove(dataDir);
+  });
+
+  it("returns JSON:API people sorted by the requested field", async () => {
+    const { app } = await import("../app.js");
+
+    const res = await request(app)
+      .get("/api/library/people?sort=medianPhotoAt&order=asc")
+      .set("Accept", "application/json");
+
+    expect(res.status).toBe(200);
+    expect(res.type).toMatch(/application\/json/);
+    expect(Array.isArray(res.body?.data)).toBe(true);
+    expect(res.body.data.every((item) => item.type === "person")).toBe(true);
+
+    const medians = res.body.data.map((entry) => entry.attributes.medianPhotoAt);
+    expect(medians).toEqual([
+      "2019-05-02T00:00:00Z",
+      "2020-01-02T00:00:00Z",
+      "2021-01-01T12:00:00Z",
+    ]);
+  });
+
+  it("supports descending ordering", async () => {
+    const { app } = await import("../app.js");
+
+    const res = await request(app)
+      .get("/api/library/people?sort=medianPhotoAt&order=desc")
+      .set("Accept", "application/json");
+
+    const medians = res.body.data.map((entry) => entry.attributes.medianPhotoAt);
+    expect(medians).toEqual([
+      "2021-01-01T12:00:00Z",
+      "2020-01-02T00:00:00Z",
+      "2019-05-02T00:00:00Z",
+    ]);
+  });
+});

--- a/backend/utils/people-index.js
+++ b/backend/utils/people-index.js
@@ -1,0 +1,122 @@
+// ./utils/people-index.js
+
+import fs from "fs-extra";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { runPythonScript } from "./run-python-script.js";
+import { getPhotosLibraryLastModified } from "./get-photos-library-last-modified.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DATA_DIR = path.join(__dirname, "..", "data", "library");
+const PEOPLE_INDEX_PATH = path.join(DATA_DIR, "people-index.json");
+const VENV_DIR = path.join(__dirname, "..", "venv");
+const PYTHON_PATH = path.join(VENV_DIR, "bin", "python3");
+const SCRIPT_PATH = path.join(__dirname, "..", "scripts", "export_people_index.py");
+
+let exportInFlight = null;
+let cachedPeople = null;
+let cachedMtime = null;
+
+async function isStale() {
+  const exists = await fs.pathExists(PEOPLE_INDEX_PATH);
+  if (!exists) return true;
+
+  try {
+    const [stats, libraryMtime] = await Promise.all([
+      fs.stat(PEOPLE_INDEX_PATH),
+      getPhotosLibraryLastModified().catch(() => null),
+    ]);
+
+    if (libraryMtime && libraryMtime instanceof Date) {
+      return libraryMtime.getTime() > stats.mtime.getTime();
+    }
+    return false;
+  } catch (err) {
+    if (err?.code === "ENOENT") return true;
+    throw err;
+  }
+}
+
+async function buildIndex() {
+  await fs.ensureDir(DATA_DIR);
+  await runPythonScript(
+    PYTHON_PATH,
+    SCRIPT_PATH,
+    ["--out", PEOPLE_INDEX_PATH],
+    undefined,
+    { streamStdout: false },
+  );
+  cachedPeople = null;
+  cachedMtime = null;
+}
+
+export async function ensurePeopleIndexUpToDate() {
+  const stale = await isStale();
+  if (!stale) return;
+
+  if (!exportInFlight) {
+    exportInFlight = buildIndex().finally(() => {
+      exportInFlight = null;
+    });
+  }
+
+  await exportInFlight;
+}
+
+async function loadPeopleIndex() {
+  await ensurePeopleIndexUpToDate();
+
+  const stats = await fs.stat(PEOPLE_INDEX_PATH);
+  if (!cachedPeople || cachedMtime !== stats.mtimeMs) {
+    const data = await fs.readJson(PEOPLE_INDEX_PATH);
+    cachedPeople = Array.isArray(data) ? data : Array.isArray(data?.people) ? data.people : [];
+    cachedMtime = stats.mtimeMs;
+  }
+
+  return cachedPeople;
+}
+
+function compareValues(a, b, direction) {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  if (a < b) return -1 * direction;
+  if (a > b) return 1 * direction;
+  return 0;
+}
+
+export async function getPeopleSummary({ sort = "medianPhotoAt", order = "asc" } = {}) {
+  const people = await loadPeopleIndex();
+  const direction = order === "desc" ? -1 : 1;
+  const key = sort || "medianPhotoAt";
+
+  const sorted = [...people].sort((a, b) => {
+    if (key === "name") {
+      return (a.name || "").localeCompare(b.name || "") * direction;
+    }
+
+    if (key === "photoCount") {
+      return compareValues(a.photoCount, b.photoCount, direction);
+    }
+
+    if (["medianPhotoAt", "earliestPhotoAt", "latestPhotoAt"].includes(key)) {
+      const aTime = a[key] ? Date.parse(a[key]) : null;
+      const bTime = b[key] ? Date.parse(b[key]) : null;
+      const cmp = compareValues(aTime, bTime, direction);
+      if (cmp !== 0) return cmp;
+      return a.name?.localeCompare(b.name || "") || 0;
+    }
+
+    return 0;
+  });
+
+  return sorted;
+}
+
+export const peopleIndexPaths = {
+  dataDir: DATA_DIR,
+  peopleIndexPath: PEOPLE_INDEX_PATH,
+};

--- a/backend/utils/slugify-name.js
+++ b/backend/utils/slugify-name.js
@@ -1,0 +1,16 @@
+// ./utils/slugify-name.js
+
+/**
+ * Generate a URL-safe, stable slug for a person's name.
+ */
+export function slugifyName(name) {
+  const base = String(name ?? "").normalize("NFKD");
+  const withoutDiacritics = base.replace(/[\u0300-\u036f]/g, "");
+
+  const slug = withoutDiacritics
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || "person";
+}

--- a/frontend/photo-filter-frontend/app/adapters/person.js
+++ b/frontend/photo-filter-frontend/app/adapters/person.js
@@ -1,0 +1,16 @@
+import ApplicationAdapter from './application';
+
+export default class PersonAdapter extends ApplicationAdapter {
+  urlForQuery(query) {
+    if (query?.scope === 'library') {
+      const { scope, ...rest } = query;
+      const host = this.host || '';
+      const namespace = this.namespace ? `/${this.namespace}` : '';
+      const base = `${host}${namespace}/library/people`;
+      const queryString = this.buildQueryString(rest);
+      return queryString ? `${base}?${queryString}` : base;
+    }
+
+    return super.urlForQuery(...arguments);
+  }
+}

--- a/frontend/photo-filter-frontend/app/controllers/people.js
+++ b/frontend/photo-filter-frontend/app/controllers/people.js
@@ -1,0 +1,20 @@
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class PeopleController extends Controller {
+  queryParams = ['sort', 'order'];
+
+  @tracked sort = 'medianPhotoAt';
+  @tracked order = 'asc';
+
+  @action
+  toggleOrder() {
+    this.order = this.order === 'asc' ? 'desc' : 'asc';
+  }
+
+  @action
+  sortBy(field) {
+    this.sort = field;
+  }
+}

--- a/frontend/photo-filter-frontend/app/models/person.js
+++ b/frontend/photo-filter-frontend/app/models/person.js
@@ -3,5 +3,10 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class PersonModel extends Model {
   @attr('string') name;
+  @attr('number') photoCount;
+  @attr('date') earliestPhotoAt;
+  @attr('date') latestPhotoAt;
+  @attr('date') medianPhotoAt;
+  @attr('string') heroUuid;
   @hasMany('photo', { async: true, inverse: 'persons' }) photos;
 }

--- a/frontend/photo-filter-frontend/app/router.js
+++ b/frontend/photo-filter-frontend/app/router.js
@@ -10,4 +10,6 @@ Router.map(function () {
   this.route('albums', function () {
     this.route('album', { path: '/:album_id' });
   });
+
+  this.route('people');
 });

--- a/frontend/photo-filter-frontend/app/routes/people.js
+++ b/frontend/photo-filter-frontend/app/routes/people.js
@@ -1,0 +1,22 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class PeopleRoute extends Route {
+  @service store;
+
+  queryParams = {
+    sort: { refreshModel: true },
+    order: { refreshModel: true },
+  };
+
+  async model(params) {
+    const sort = params.sort ?? 'medianPhotoAt';
+    const order = params.order ?? 'asc';
+
+    return this.store.query('person', {
+      scope: 'library',
+      sort,
+      order,
+    });
+  }
+}

--- a/frontend/photo-filter-frontend/app/templates/application.hbs
+++ b/frontend/photo-filter-frontend/app/templates/application.hbs
@@ -72,6 +72,18 @@
       {{! Time navigation }}
       <TimeNav />
 
+      <h3 class="text-lg font-semibold mb-2 mt-4">Browse</h3>
+      <ul class="menu p-0 w-full mb-4">
+        <li class="mb-1">
+          <LinkTo
+            @route="people"
+            class="rounded hover:bg-gray-200 px-2 py-1"
+          >
+            People &amp; Pets
+          </LinkTo>
+        </li>
+      </ul>
+
       {{! Albums list: from application route model }}
       <h3 class="text-lg font-semibold mb-2 mt-4">Albums</h3>
       <ul class="menu p-0 w-full mb-4">

--- a/frontend/photo-filter-frontend/app/templates/people.hbs
+++ b/frontend/photo-filter-frontend/app/templates/people.hbs
@@ -1,0 +1,42 @@
+<section class="people-header flex items-center justify-between mb-6">
+  <div>
+    <h1 class="text-2xl font-bold">People &amp; Pets</h1>
+    <p class="text-sm opacity-70">Library-wide view of everyone in Photos.</p>
+  </div>
+
+  <div class="sort-controls flex items-center gap-3">
+    <button
+      type="button"
+      class="btn btn-sm"
+      data-test-sort-median
+      {{on "click" (fn this.sortBy "medianPhotoAt")}}
+    >
+      Sort by median date
+    </button>
+    <button
+      type="button"
+      class="btn btn-sm"
+      data-test-toggle-order
+      {{on "click" this.toggleOrder}}
+    >
+      {{if (eq this.order "asc") "Oldest → Newest" "Newest → Oldest"}}
+    </button>
+  </div>
+</section>
+
+<section class="people-grid grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+  {{#each @model as |person|}}
+    <article class="person-tile card bg-base-100 shadow">
+      <div class="card-body">
+        <div class="avatar-placeholder mb-2 text-sm font-semibold">
+          {{person.name}}
+        </div>
+        <div class="person-meta space-y-1">
+          <h2 class="text-lg font-semibold person-name">{{person.name}}</h2>
+          <p class="text-sm opacity-80">{{person.photoCount}} photos</p>
+          <p class="text-xs opacity-70">Median: {{person.medianPhotoAt}}</p>
+        </div>
+      </div>
+    </article>
+  {{/each}}
+</section>

--- a/frontend/photo-filter-frontend/tests/acceptance/people-route-test.js
+++ b/frontend/photo-filter-frontend/tests/acceptance/people-route-test.js
@@ -1,0 +1,104 @@
+import { module, test } from 'qunit';
+import { visit, currentURL, findAll, click, settled } from '@ember/test-helpers';
+import { setupApplicationTest } from 'photo-filter-frontend/tests/helpers';
+
+function buildResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/vnd.api+json',
+    },
+  });
+}
+
+const ascPayload = {
+  data: [
+    {
+      type: 'person',
+      id: 'carol',
+      attributes: {
+        name: 'Carol',
+        photoCount: 4,
+        medianPhotoAt: '2019-05-02T00:00:00Z',
+      },
+    },
+    {
+      type: 'person',
+      id: 'alice',
+      attributes: {
+        name: 'Alice',
+        photoCount: 3,
+        medianPhotoAt: '2020-01-02T00:00:00Z',
+      },
+    },
+    {
+      type: 'person',
+      id: 'bob',
+      attributes: {
+        name: 'Bob',
+        photoCount: 2,
+        medianPhotoAt: '2021-01-01T12:00:00Z',
+      },
+    },
+  ],
+  meta: { sort: 'medianPhotoAt', order: 'asc' },
+};
+
+const descPayload = {
+  data: [...ascPayload.data].reverse(),
+  meta: { sort: 'medianPhotoAt', order: 'desc' },
+};
+
+module('Acceptance | people route', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.originalFetch = window.fetch;
+    window.fetch = async (input, options = {}) => {
+      const url = typeof input === 'string' ? input : input.url;
+      const parsed = new URL(url, window.location.origin);
+
+      if (parsed.pathname.endsWith('/api/albums')) {
+        return buildResponse({ data: [] });
+      }
+
+      if (parsed.pathname.endsWith('/api/library/people')) {
+        const order = parsed.searchParams.get('order') || 'asc';
+        return buildResponse(order === 'desc' ? descPayload : ascPayload);
+      }
+
+      if (this.originalFetch) {
+        return this.originalFetch(input, options);
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+  });
+
+  hooks.afterEach(function () {
+    window.fetch = this.originalFetch;
+  });
+
+  test('People route lists people and supports toggling order', async function (assert) {
+    await visit('/people');
+
+    assert.strictEqual(currentURL(), '/people', 'navigated to /people');
+
+    let names = findAll('.person-name').map((el) => el.textContent.trim());
+    assert.deepEqual(
+      names,
+      ['Carol', 'Alice', 'Bob'],
+      'renders people sorted by ascending medianPhotoAt',
+    );
+
+    await click('[data-test-toggle-order]');
+    await settled();
+
+    names = findAll('.person-name').map((el) => el.textContent.trim());
+    assert.deepEqual(
+      names,
+      ['Bob', 'Alice', 'Carol'],
+      'reorders people when sort order toggles',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add an osxphotos-powered exporter and helper to build a library-wide people index
- expose a new /api/library/people endpoint plus slugified person ids and test coverage
- surface a People route in the Ember app with sorting controls, adapter tweaks, and acceptance coverage

## Testing
- npm test --prefix backend -- api.people-library.test.js (fails: missing Jest dependency in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e00c6206c83308ef470ee2ae451d1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a library-wide people index and endpoint with slugged IDs and sorting, and surfaces a new People route in the Ember app with adapter, model updates, and tests.
> 
> - **Backend**
>   - **Library-wide people index**:
>     - Add `utils/people-index.js` with `ensurePeopleIndexUpToDate`, `getPeopleSummary`, caching, and staleness checks.
>     - New Python exporter `scripts/export_people_index.py`; fixture `testdata/library/people-index.json`.
>     - New endpoint `GET /api/library/people` via `getLibraryPeople` in `controllers/api/people-controller.js` (JSON:API with sort/order), plus tests `tests/api.people-library.test.js`.
>   - **Slug handling**: Introduce `utils/slugify-name.js` and use in `albums-controller.js` and `photos-controller.js` (remove inline slugify helpers).
> - **Frontend**
>   - **People route**: Add route `people` with model query to library scope, sorting controls (`controllers/people.js`, `routes/people.js`, `templates/people.hbs`).
>   - **Data layer**: `adapters/person.js` targets `/library/people`; `models/person.js` gains `photoCount`, `earliestPhotoAt`, `latestPhotoAt`, `medianPhotoAt`, `heroUuid`.
>   - **Navigation**: Add "People & Pets" link in `templates/application.hbs`.
>   - **Tests**: Acceptance test `tests/acceptance/people-route-test.js` verifies listing and order toggling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58fa37dd89e4eab588967209169306f620682c5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->