### PR TITLE
Fix person adapter query URL construction

### DIFF
--- a/frontend/photo-filter-frontend/app/adapters/person.js
+++ b/frontend/photo-filter-frontend/app/adapters/person.js
@@ -1,16 +1,16 @@
 import ApplicationAdapter from './application';
 
 export default class PersonAdapter extends ApplicationAdapter {
-  urlForQuery(query) {
+  urlForQuery(query, modelName) {
     if (query?.scope === 'library') {
-      const { scope, ...rest } = query;
+      delete query.scope;
+
       const host = this.host || '';
       const namespace = this.namespace ? `/${this.namespace}` : '';
-      const base = `${host}${namespace}/library/people`;
-      const queryString = this.buildQueryString(rest);
-      return queryString ? `${base}?${queryString}` : base;
+
+      return `${host}${namespace}/library/people`;
     }
 
-    return super.urlForQuery(...arguments);
+    return super.urlForQuery(query, modelName);
   }
 }


### PR DESCRIPTION
## Summary
- update the person adapter to avoid calling a missing buildQueryString helper
- direct library-scoped queries to /library/people while letting Ember Data append query params

## Testing
- npm run test:ember -- --filter people *(fails: ember command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5b76b1048330bcaae7445b115bba)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Routes library-scoped person queries to `/library/people` and lets Ember Data handle query params.
> 
> - **Frontend**
>   - **PersonAdapter (`app/adapters/person.js`)**:
>     - Route `scope: 'library'` queries to `'/library/people'` and remove `query.scope`.
>     - Defer query-string construction to Ember Data instead of manual building.
>     - Update `urlForQuery` signature to `(query, modelName)` and delegate to `super.urlForQuery(query, modelName)` for non-library scopes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e470efc839466d6037e0bb1367d6a6ac09f020b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->