### PR TITLE
Refine library hero images and people sorting

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -11,6 +11,7 @@ import {
 } from "./config/storage-paths.js";
 import { getPeopleByFilename } from "./controllers/api/filename-controller.js";
 import { createImagesMiddleware } from "./middleware/images.js";
+import { createLibraryImagesMiddleware } from "./middleware/library-images.js";
 
 const app = express();
 
@@ -70,6 +71,7 @@ app.use(express.static(path.join(__dirname, "public")));
 app.use("/data/albums", express.static(path.join(getLocalRoot(), "albums")));
 
 app.get("/images/:albumUUID/:imageName", createImagesMiddleware());
+app.get("/library/images/:exportedName", createLibraryImagesMiddleware());
 
 // Query variant forwards to the same controller
 app.get("/api/people/by-filename", (req, res) => {

--- a/backend/controllers/api/people-controller.js
+++ b/backend/controllers/api/people-controller.js
@@ -9,7 +9,6 @@ import {
   ensurePeopleIndexUpToDate,
   getPeopleSummary,
 } from "../../utils/people-index.js";
-import { slugifyName } from "../../utils/slugify-name.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -37,11 +36,21 @@ const PersonSerializer = new Serializer("person", {
   id: "id",
   attributes: [
     "name",
+    "displayName",
     "photoCount",
     "earliestPhotoAt",
     "latestPhotoAt",
     "medianPhotoAt",
     "heroUuid",
+    "heroExportedName",
+    "heroUuidEarliest",
+    "heroUuidMedian",
+    "heroUuidLatest",
+    "heroUuidHighlight",
+    "earliestExportedName",
+    "medianExportedName",
+    "latestExportedName",
+    "highlightExportedName",
   ],
   keyForAttribute: "camelCase",
   pluralizeType: false,
@@ -164,12 +173,7 @@ export const getLibraryPeople = async (req, res) => {
     await ensurePeopleIndexUpToDate();
     const people = await getPeopleSummary({ sort, order });
 
-    const mapped = people.map((person) => ({
-      ...person,
-      id: slugifyName(person.name),
-    }));
-
-    const payload = PersonSerializer.serialize(mapped);
+    const payload = PersonSerializer.serialize(people);
 
     return res.json({
       ...payload,

--- a/backend/middleware/images.js
+++ b/backend/middleware/images.js
@@ -92,7 +92,7 @@ export function createImagesMiddleware({
 
 export default createImagesMiddleware;
 
-async function applyCachingHeaders(res, fsClient, filePath) {
+export async function applyCachingHeaders(res, fsClient, filePath) {
   let stats;
   try {
     stats = await fsClient.stat(filePath);

--- a/backend/middleware/library-images.js
+++ b/backend/middleware/library-images.js
@@ -1,0 +1,65 @@
+import fs from "fs-extra";
+import path from "path";
+import {
+  getLibraryPathForExportedName,
+  getLibraryRoot,
+} from "../config/storage-paths.js";
+import { resolveLibraryCandidate } from "../utils/library-files.js";
+import { applyCachingHeaders } from "./images.js";
+
+function isTraversalAttempt(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return Boolean(relative) && (relative.startsWith("..") || path.isAbsolute(relative));
+}
+
+function isSafeBasename(name) {
+  if (!name) return false;
+
+  if (name === "." || name === "..") return false;
+
+  const normalized = path.basename(name);
+  if (normalized !== name) return false;
+
+  if (name.includes("/") || name.includes("\\")) return false;
+
+  return true;
+}
+
+export function createLibraryImagesMiddleware({ fsClient = fs, logger = console } = {}) {
+  const libraryRoot = path.resolve(getLibraryRoot());
+
+  return async function libraryImagesMiddleware(req, res) {
+    const { exportedName } = req.params;
+
+    if (!isSafeBasename(exportedName)) {
+      return res.status(400).json({ error: "Invalid path" });
+    }
+
+    const basePath = getLibraryPathForExportedName(exportedName);
+    if (!basePath) {
+      logger.warn?.("library-images: no basePath", { exportedName });
+      return res.status(404).json({ error: "Image not found" });
+    }
+
+    const absoluteBase = path.resolve(basePath);
+    if (isTraversalAttempt(libraryRoot, absoluteBase)) {
+      return res.status(400).json({ error: "Invalid path" });
+    }
+
+    try {
+      const resolved = await resolveLibraryCandidate(absoluteBase, exportedName);
+      if (resolved && !isTraversalAttempt(libraryRoot, resolved)) {
+        await applyCachingHeaders(res, fsClient, resolved);
+        return res.sendFile(resolved, { cacheControl: false });
+      }
+
+      logger.warn?.("library-images: not found", { exportedName });
+      return res.status(404).json({ error: "Image not found" });
+    } catch (err) {
+      logger.error?.("library-images: unexpected error", { exportedName, err });
+      return res.status(500).json({ error: "Internal Server Error" });
+    }
+  };
+}
+
+export default createLibraryImagesMiddleware;

--- a/backend/scripts/export_people_index.py
+++ b/backend/scripts/export_people_index.py
@@ -1,18 +1,22 @@
 #!/usr/bin/env python3
 # ./scripts/export_people_index.py
 
-#!/usr/bin/env python3
-# ./scripts/export_people_index.py
-
 import argparse
 import json
-from datetime import timezone
+import os
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Iterable, Optional
 
 import osxphotos
 
+# Keep this in sync with backend/utils/export-images.js (osxphotos export).
+# The template is expected to produce a flat basename; directory components are
+# intentionally disallowed because /library/images only serves basenames.
+FILENAME_TEMPLATE_DEFAULT = "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}"
 
-def isoformat_utc(dt):
+
+def isoformat_utc(dt: Optional[datetime]) -> Optional[str]:
     if dt is None:
         return None
     if dt.tzinfo is None:
@@ -20,44 +24,130 @@ def isoformat_utc(dt):
     return dt.astimezone(timezone.utc).isoformat()
 
 
-def build_people_index(db):
-    people = {}
+def atomic_write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(tmp_path, path)
 
-    for photo in db.photos():
-        date = getattr(photo, "date", None)
-        if not date:
+
+def normalize_jpeg_ext(raw: Optional[str]) -> Optional[str]:
+    if not raw:
+        return None
+    ext = raw if raw.startswith(".") else f".{raw}"
+    return ext
+
+
+def rendered_exported_name(photo: osxphotos.PhotoInfo, template: str, jpeg_ext: Optional[str]) -> Optional[str]:
+    try:
+        rendered = photo.render_template(
+            template,
+            none_str="",
+            path_sep="_",
+            filename=True,
+        )
+    except Exception:
+        return None
+
+    candidate = None
+    if isinstance(rendered, (list, tuple)):
+        candidate = rendered[0] if rendered else None
+    elif isinstance(rendered, str):
+        candidate = rendered
+
+    if not candidate:
+        return None
+
+    lower = candidate.lower()
+    if jpeg_ext and (lower.endswith(".jpg") or lower.endswith(".jpeg")):
+        stem = candidate.rsplit(".", 1)[0]
+        candidate = f"{stem}{jpeg_ext}"
+    elif jpeg_ext and not Path(candidate).suffix:
+        candidate = f"{candidate}{jpeg_ext}"
+
+    return candidate
+
+
+def choose_highlight_photo(photos: Iterable[osxphotos.PhotoInfo]) -> Optional[osxphotos.PhotoInfo]:
+    best_photo = None
+    best_score = None
+
+    for photo in photos:
+        score = getattr(photo, "score", None)
+        value = None
+        if score is not None:
+            value = getattr(score, "highlight_visibility", None)
+            if value is None and isinstance(score, dict):
+                value = score.get("highlight_visibility")
+            if value is None:
+                value = getattr(score, "overall", None)
+                if value is None and isinstance(score, dict):
+                    value = score.get("overall")
+
+        if value is None:
             continue
 
-        persons = getattr(photo, "persons", None) or []
-        uuid = getattr(photo, "uuid", None)
+        if best_score is None or value > best_score:
+            best_score = value
+            best_photo = photo
 
-        for person_name in persons:
-            bucket = people.setdefault(person_name, [])
-            bucket.append((date, uuid))
+    return best_photo
 
+
+def summarize_person(person: osxphotos.PersonInfo, template: str, jpeg_ext: Optional[str]):
+    photos = [p for p in person.photos if getattr(p, "date", None)]
+    if not photos:
+        return None
+
+    sorted_photos = sorted(photos, key=lambda p: p.date or datetime.min)
+    earliest = sorted_photos[0]
+    latest = sorted_photos[-1]
+    median = sorted_photos[len(sorted_photos) // 2]
+
+    highlight = choose_highlight_photo(sorted_photos) or median
+
+    def exported_name(photo: osxphotos.PhotoInfo) -> Optional[str]:
+        return rendered_exported_name(photo, template, jpeg_ext)
+
+    return {
+        "id": f"person:{person.uuid}",
+        "name": person.name or None,
+        "displayName": getattr(person, "display_name", None) or person.name or None,
+        "photoCount": len(sorted_photos),
+        "earliestPhotoAt": isoformat_utc(getattr(earliest, "date", None)),
+        "medianPhotoAt": isoformat_utc(getattr(median, "date", None)),
+        "latestPhotoAt": isoformat_utc(getattr(latest, "date", None)),
+        "heroUuidEarliest": getattr(earliest, "uuid", None),
+        "heroUuidMedian": getattr(median, "uuid", None),
+        "heroUuidLatest": getattr(latest, "uuid", None),
+        "heroUuidHighlight": getattr(highlight, "uuid", None),
+        "heroUuid": getattr(median, "uuid", None),
+        "earliestExportedName": exported_name(earliest),
+        "medianExportedName": exported_name(median),
+        "latestExportedName": exported_name(latest),
+        "highlightExportedName": exported_name(highlight),
+    }
+
+
+def build_people_index(db: osxphotos.PhotosDB, template: str, jpeg_ext: Optional[str]):
+    """Return a list of people summaries with hero UUIDs and exported filenames.
+
+    Each entry contains:
+    * id: "person:<uuid>" (stable Photos person id)
+    * name / displayName (may be empty for unnamed people)
+    * photoCount and ISO-8601 timestamps for earliest/median/latest photos
+    * heroUuid* fields for earliest/median/latest/highlight photos
+    * exported basename fields for those hero images
+    """
     summaries = []
 
-    for name, entries in people.items():
-        if not entries:
-            continue
-
-        sorted_entries = sorted(entries, key=lambda pair: pair[0])
-
-        n = len(sorted_entries)
-        median_index = n // 2
-        median_entry = sorted_entries[median_index]
-
-        summaries.append(
-            {
-                "id": f"person:{name}",
-                "name": name,
-                "photoCount": n,
-                "earliestPhotoAt": isoformat_utc(sorted_entries[0][0]),
-                "latestPhotoAt": isoformat_utc(sorted_entries[-1][0]),
-                "medianPhotoAt": isoformat_utc(median_entry[0]),
-                "heroUuid": median_entry[1],
-            }
-        )
+    for person in db.person_info:
+        summary = summarize_person(person, template, jpeg_ext)
+        if summary is not None:
+            summaries.append(summary)
 
     return summaries
 
@@ -70,12 +160,13 @@ def main():
 
     db = osxphotos.PhotosDB(dbfile=args.db) if args.db else osxphotos.PhotosDB()
 
-    summaries = build_people_index(db)
+    filename_template = os.environ.get("FILENAME_TEMPLATE", FILENAME_TEMPLATE_DEFAULT)
+    jpeg_ext = normalize_jpeg_ext(os.environ.get("JPEG_EXT"))
+
+    summaries = build_people_index(db, filename_template, jpeg_ext)
 
     out_path = Path(args.out)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    with out_path.open("w", encoding="utf-8") as fh:
-        json.dump(summaries, fh, ensure_ascii=False, indent=2)
+    atomic_write_json(out_path, summaries)
 
 
 if __name__ == "__main__":

--- a/backend/testdata/library/people-index.json
+++ b/backend/testdata/library/people-index.json
@@ -1,29 +1,53 @@
 [
   {
-    "id": "person:alice",
+    "id": "person:1111-2222",
     "name": "Alice",
     "photoCount": 3,
     "earliestPhotoAt": "2020-01-01T00:00:00Z",
     "latestPhotoAt": "2020-01-03T00:00:00Z",
     "medianPhotoAt": "2020-01-02T00:00:00Z",
-    "heroUuid": "hero-a"
+    "heroUuid": "hero-a",
+    "heroUuidEarliest": "alice-earliest-uuid",
+    "heroUuidMedian": "alice-median-uuid",
+    "heroUuidLatest": "alice-latest-uuid",
+    "heroUuidHighlight": "alice-highlight-uuid",
+    "earliestExportedName": "alice-earliest.jpg",
+    "medianExportedName": "alice-median.jpg",
+    "latestExportedName": "alice-latest.jpg",
+    "highlightExportedName": "alice-highlight.jpg"
   },
   {
-    "id": "person:bob",
+    "id": "person:3333-4444",
     "name": "Bob",
     "photoCount": 2,
     "earliestPhotoAt": "2021-01-01T00:00:00Z",
     "latestPhotoAt": "2021-01-02T00:00:00Z",
     "medianPhotoAt": "2021-01-01T12:00:00Z",
-    "heroUuid": "hero-b"
+    "heroUuid": "hero-b",
+    "heroUuidEarliest": "bob-earliest-uuid",
+    "heroUuidMedian": "bob-median-uuid",
+    "heroUuidLatest": "bob-latest-uuid",
+    "heroUuidHighlight": "bob-highlight-uuid",
+    "earliestExportedName": "bob-earliest.jpg",
+    "medianExportedName": "bob-median.jpg",
+    "latestExportedName": "bob-latest.jpg",
+    "highlightExportedName": "bob-highlight.jpg"
   },
   {
-    "id": "person:carol",
+    "id": "person:5555-6666",
     "name": "Carol",
     "photoCount": 4,
     "earliestPhotoAt": "2019-05-01T00:00:00Z",
     "latestPhotoAt": "2019-05-04T00:00:00Z",
     "medianPhotoAt": "2019-05-02T00:00:00Z",
-    "heroUuid": "hero-c"
+    "heroUuid": "hero-c",
+    "heroUuidEarliest": "carol-earliest-uuid",
+    "heroUuidMedian": "carol-median-uuid",
+    "heroUuidLatest": "carol-latest-uuid",
+    "heroUuidHighlight": "carol-highlight-uuid",
+    "earliestExportedName": "carol-earliest.jpg",
+    "medianExportedName": "carol-median.jpg",
+    "latestExportedName": "carol-latest.jpg",
+    "highlightExportedName": "carol-highlight.jpg"
   }
 ]

--- a/backend/tests/api.people-library.test.js
+++ b/backend/tests/api.people-library.test.js
@@ -59,4 +59,63 @@ describe("GET /api/library/people", () => {
       "2019-05-02T00:00:00Z",
     ]);
   });
+
+  it("selects heroes based on sort mode", async () => {
+    const { app } = await import("../app.js");
+
+    const scenarios = [
+      {
+        sort: "earliestPhotoAt",
+        expected: [
+          "carol-earliest.jpg",
+          "alice-earliest.jpg",
+          "bob-earliest.jpg",
+        ],
+      },
+      {
+        sort: "medianPhotoAt",
+        expected: [
+          "carol-median.jpg",
+          "alice-median.jpg",
+          "bob-median.jpg",
+        ],
+      },
+      {
+        sort: "latestPhotoAt",
+        expected: [
+          "carol-latest.jpg",
+          "alice-latest.jpg",
+          "bob-latest.jpg",
+        ],
+      },
+      {
+        sort: "name",
+        expected: [
+          "alice-highlight.jpg",
+          "bob-highlight.jpg",
+          "carol-highlight.jpg",
+        ],
+      },
+      {
+        sort: "photoCount",
+        expected: [
+          "bob-highlight.jpg",
+          "alice-highlight.jpg",
+          "carol-highlight.jpg",
+        ],
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const res = await request(app)
+        .get(`/api/library/people?sort=${scenario.sort}`)
+        .set("Accept", "application/json");
+
+      expect(res.status).toBe(200);
+      const heroes = res.body.data.map(
+        (entry) => entry.attributes.heroExportedName,
+      );
+      expect(heroes).toEqual(scenario.expected);
+    }
+  });
 });

--- a/backend/tests/library-images.test.js
+++ b/backend/tests/library-images.test.js
@@ -1,0 +1,58 @@
+import express from "express";
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import request from "supertest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function makeExportedName(stem = "test") {
+  return `20200101T000000000000Z-${stem}.jpg`;
+}
+
+describe("GET /library/images/:exportedName", () => {
+  let app;
+  let libraryRoot;
+  const exportedName = makeExportedName("photo");
+
+  beforeAll(async () => {
+    libraryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pf-library-"));
+    process.env.PF_LIBRARY_ROOT = libraryRoot;
+
+    // Create a file that matches the expected library layout
+    const targetPath = path.join(libraryRoot, "2020", "01", "01", exportedName);
+    await fs.ensureDir(path.dirname(targetPath));
+    await fs.writeFile(targetPath, "test-image");
+
+    const module = await import("../middleware/library-images.js");
+    const createLibraryImagesMiddleware = module.createLibraryImagesMiddleware;
+
+    app = express();
+    app.get("/library/images/:exportedName", createLibraryImagesMiddleware({ fsClient: fs }));
+  });
+
+  afterAll(async () => {
+    Object.assign(process.env, ORIGINAL_ENV);
+    if (!ORIGINAL_ENV.PF_LIBRARY_ROOT) {
+      delete process.env.PF_LIBRARY_ROOT;
+    }
+    await fs.remove(libraryRoot).catch(() => {});
+  });
+
+  it("serves a known exported name", async () => {
+    const res = await request(app).get(`/library/images/${exportedName}`);
+    expect(res.status).toBe(200);
+    expect(res.text).toBe("test-image");
+  });
+
+  it("rejects unsafe basenames", async () => {
+    const res = await request(app).get("/library/images/../../etc/passwd");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when basename is well-formed but missing", async () => {
+    const missing = makeExportedName("missing");
+    const res = await request(app).get(`/library/images/${missing}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/backend/utils/people-index.js
+++ b/backend/utils/people-index.js
@@ -15,6 +15,9 @@ const PEOPLE_INDEX_PATH = path.join(DATA_DIR, "people-index.json");
 const VENV_DIR = path.join(__dirname, "..", "venv");
 const PYTHON_PATH = path.join(VENV_DIR, "bin", "python3");
 const SCRIPT_PATH = path.join(__dirname, "..", "scripts", "export_people_index.py");
+const FILENAME_TEMPLATE_DEFAULT =
+  "{created.utc.strftime,%Y%m%dT%H%M%S%fZ}-{original_name}";
+const JPEG_EXT_DEFAULT = "jpg";
 
 let exportInFlight = null;
 let cachedPeople = null;
@@ -47,7 +50,16 @@ async function buildIndex() {
     SCRIPT_PATH,
     ["--out", PEOPLE_INDEX_PATH],
     undefined,
-    { streamStdout: false },
+    {
+      streamStdout: false,
+      // Keep the exporter aligned with the osxphotos image export pipeline so
+      // hero filenames resolve correctly against PF_LIBRARY_ROOT.
+      env: {
+        FILENAME_TEMPLATE:
+          process.env.FILENAME_TEMPLATE || FILENAME_TEMPLATE_DEFAULT,
+        JPEG_EXT: process.env.JPEG_EXT || JPEG_EXT_DEFAULT,
+      },
+    },
   );
   cachedPeople = null;
   cachedMtime = null;
@@ -88,6 +100,62 @@ function compareValues(a, b, direction) {
   return 0;
 }
 
+function normalizedName(person) {
+  return (person.displayName || person.name || "").trim();
+}
+
+function compareNames(a, b, direction) {
+  const nameA = normalizedName(a);
+  const nameB = normalizedName(b);
+
+  if (!nameA && !nameB) return 0;
+  if (!nameA) return 1;
+  if (!nameB) return -1;
+
+  return nameA.localeCompare(nameB, undefined, { sensitivity: "base" }) * direction;
+}
+
+function selectHero(person, sortKey) {
+  // Backend prefers sort-aware hero selection when the richer fields are
+  // present; fall back to legacy hero fields for older people-index files.
+  const heroFallbackExported = [
+    person.heroExportedName,
+    person.highlightExportedName,
+    person.medianExportedName,
+    person.latestExportedName,
+    person.earliestExportedName,
+  ];
+  const heroFallbackUuid = [
+    person.heroUuidHighlight,
+    person.heroUuidMedian,
+    person.heroUuidLatest,
+    person.heroUuidEarliest,
+    person.heroUuid,
+  ];
+
+  function buildSelection(exported, uuid) {
+    return {
+      heroExportedName: exported ?? heroFallbackExported.find(Boolean) ?? null,
+      heroUuid: uuid ?? heroFallbackUuid.find(Boolean) ?? null,
+    };
+  }
+
+  if (sortKey === "earliestPhotoAt") {
+    return buildSelection(person.earliestExportedName, person.heroUuidEarliest);
+  }
+
+  if (sortKey === "latestPhotoAt") {
+    return buildSelection(person.latestExportedName, person.heroUuidLatest);
+  }
+
+  if (sortKey === "medianPhotoAt") {
+    return buildSelection(person.medianExportedName, person.heroUuidMedian);
+  }
+
+  // Aggregate sorts (name, photoCount, or unknown)
+  return buildSelection(person.highlightExportedName, person.heroUuidHighlight);
+}
+
 export async function getPeopleSummary({ sort = "medianPhotoAt", order = "asc" } = {}) {
   const people = await loadPeopleIndex();
   const direction = order === "desc" ? -1 : 1;
@@ -95,11 +163,13 @@ export async function getPeopleSummary({ sort = "medianPhotoAt", order = "asc" }
 
   const sorted = [...people].sort((a, b) => {
     if (key === "name") {
-      return (a.name || "").localeCompare(b.name || "") * direction;
+      return compareNames(a, b, direction);
     }
 
     if (key === "photoCount") {
-      return compareValues(a.photoCount, b.photoCount, direction);
+      const cmp = compareValues(a.photoCount, b.photoCount, direction);
+      if (cmp !== 0) return cmp;
+      return compareNames(a, b, 1);
     }
 
     if (["medianPhotoAt", "earliestPhotoAt", "latestPhotoAt"].includes(key)) {
@@ -107,13 +177,16 @@ export async function getPeopleSummary({ sort = "medianPhotoAt", order = "asc" }
       const bTime = b[key] ? Date.parse(b[key]) : null;
       const cmp = compareValues(aTime, bTime, direction);
       if (cmp !== 0) return cmp;
-      return a.name?.localeCompare(b.name || "") || 0;
+      return compareNames(a, b, 1);
     }
 
-    return 0;
+    return compareNames(a, b, direction);
   });
 
-  return sorted;
+  return sorted.map((person) => ({
+    ...person,
+    ...selectHero(person, key),
+  }));
 }
 
 export const peopleIndexPaths = {

--- a/backend/utils/run-python-script.js
+++ b/backend/utils/run-python-script.js
@@ -38,6 +38,7 @@ export async function runPythonScript(
     logStream: providedLogStream,
     appendLog = true,
     streamStdout = true,
+    env: envOverrides = {},
   } = options;
 
   if (streamStdout && !outputPath) {
@@ -88,7 +89,7 @@ export async function runPythonScript(
 
   const child = spawn(pythonPath, spawnArgs, {
     stdio: ["ignore", "pipe", "pipe"],
-    env: process.env,
+    env: { ...process.env, ...envOverrides },
   });
 
   const printableCommand = [pythonPath, ...spawnArgs]

--- a/frontend/photo-filter-frontend/app/controllers/people.js
+++ b/frontend/photo-filter-frontend/app/controllers/people.js
@@ -8,13 +8,61 @@ export default class PeopleController extends Controller {
   @tracked sort = 'medianPhotoAt';
   @tracked order = 'asc';
 
+  sortOptions = [
+    { value: 'name', label: 'Name' },
+    { value: 'earliestPhotoAt', label: 'Earliest date' },
+    { value: 'medianPhotoAt', label: 'Median date' },
+    { value: 'latestPhotoAt', label: 'Most recent date' },
+    { value: 'photoCount', label: 'Photo count' },
+  ];
+
+  get orderLabel() {
+    if (this.sort === 'name') {
+      return this.order === 'asc' ? 'A → Z' : 'Z → A';
+    }
+
+    if (this.sort === 'photoCount') {
+      return this.order === 'asc'
+        ? 'Fewest → Most photos'
+        : 'Most → Fewest photos';
+    }
+
+    return this.order === 'asc' ? 'Oldest → Newest' : 'Newest → Oldest';
+  }
+
+  displayNameFor(person) {
+    return person.displayName || person.name || 'Unnamed person';
+  }
+
+  // Backend typically supplies a sort-aware heroExportedName; this helper keeps
+  // tests and older index files working by falling back to per-mode filenames.
+  heroFilenameFor(person) {
+    if (person.heroExportedName) {
+      return person.heroExportedName;
+    }
+
+    if (this.sort === 'earliestPhotoAt') {
+      return person.earliestExportedName || person.heroExportedName;
+    }
+
+    if (this.sort === 'latestPhotoAt') {
+      return person.latestExportedName || person.heroExportedName;
+    }
+
+    if (this.sort === 'photoCount' || this.sort === 'name') {
+      return person.highlightExportedName || person.heroExportedName;
+    }
+
+    return person.medianExportedName || person.heroExportedName;
+  }
+
   @action
   toggleOrder() {
     this.order = this.order === 'asc' ? 'desc' : 'asc';
   }
 
   @action
-  sortBy(field) {
-    this.sort = field;
+  updateSort(event) {
+    this.sort = event.target.value;
   }
 }

--- a/frontend/photo-filter-frontend/app/helpers/library-image-url.ts
+++ b/frontend/photo-filter-frontend/app/helpers/library-image-url.ts
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import libraryImageUrl from 'photo-filter-frontend/utils/library-image-url';
+
+export default helper(function libraryImageUrlHelper([filename]) {
+  return libraryImageUrl(filename);
+});

--- a/frontend/photo-filter-frontend/app/models/person.js
+++ b/frontend/photo-filter-frontend/app/models/person.js
@@ -3,10 +3,20 @@ import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class PersonModel extends Model {
   @attr('string') name;
+  @attr('string') displayName;
   @attr('number') photoCount;
   @attr('date') earliestPhotoAt;
   @attr('date') latestPhotoAt;
   @attr('date') medianPhotoAt;
   @attr('string') heroUuid;
+  @attr('string') heroExportedName;
+  @attr('string') heroUuidEarliest;
+  @attr('string') heroUuidMedian;
+  @attr('string') heroUuidLatest;
+  @attr('string') heroUuidHighlight;
+  @attr('string') earliestExportedName;
+  @attr('string') medianExportedName;
+  @attr('string') latestExportedName;
+  @attr('string') highlightExportedName;
   @hasMany('photo', { async: true, inverse: 'persons' }) photos;
 }

--- a/frontend/photo-filter-frontend/app/templates/people.hbs
+++ b/frontend/photo-filter-frontend/app/templates/people.hbs
@@ -5,21 +5,28 @@
   </div>
 
   <div class="sort-controls flex items-center gap-3">
-    <button
-      type="button"
-      class="btn btn-sm"
-      data-test-sort-median
-      {{on "click" (fn this.sortBy "medianPhotoAt")}}
+    <label class="text-sm font-semibold" for="people-sort-select">Sort</label>
+    <select
+      id="people-sort-select"
+      data-test-people-sort-select
+      class="select select-bordered select-sm"
+      {{on "change" this.updateSort}}
+      value={{this.sort}}
     >
-      Sort by median date
-    </button>
+      {{#each this.sortOptions as |option|}}
+        <option value={{option.value}} selected={{eq option.value this.sort}}>
+          {{option.label}}
+        </option>
+      {{/each}}
+    </select>
+
     <button
       type="button"
       class="btn btn-sm"
       data-test-toggle-order
       {{on "click" this.toggleOrder}}
     >
-      {{if (eq this.order "asc") "Oldest → Newest" "Newest → Oldest"}}
+      {{this.orderLabel}}
     </button>
   </div>
 </section>
@@ -27,14 +34,34 @@
 <section class="people-grid grid gap-4 md:grid-cols-2 lg:grid-cols-3">
   {{#each @model as |person|}}
     <article class="person-tile card bg-base-100 shadow">
-      <div class="card-body">
-        <div class="avatar-placeholder mb-2 text-sm font-semibold">
-          {{person.name}}
-        </div>
+      <div class="card-body gap-3">
+        {{#let (library-image-url (this.heroFilenameFor person)) as |heroUrl|}}
+          {{#if heroUrl}}
+            <img
+              src={{heroUrl}}
+              alt={{this.displayNameFor person}}
+              class="w-full rounded-xl object-cover aspect-square bg-base-300"
+              loading="lazy"
+            />
+          {{else}}
+            <div class="w-full rounded-xl aspect-square bg-base-200 flex items-center justify-center text-sm text-base-content/60">
+              No image available
+            </div>
+          {{/if}}
+        {{/let}}
+
         <div class="person-meta space-y-1">
-          <h2 class="text-lg font-semibold person-name">{{person.name}}</h2>
+          <h2 class="text-lg font-semibold person-name">{{this.displayNameFor person}}</h2>
           <p class="text-sm opacity-80">{{person.photoCount}} photos</p>
-          <p class="text-xs opacity-70">Median: {{person.medianPhotoAt}}</p>
+          <p class="text-xs opacity-70">
+            {{#if (eq this.sort "earliestPhotoAt")}}
+              Earliest: {{person.earliestPhotoAt}}
+            {{else if (eq this.sort "latestPhotoAt")}}
+              Latest: {{person.latestPhotoAt}}
+            {{else}}
+              Median: {{person.medianPhotoAt}}
+            {{/if}}
+          </p>
         </div>
       </div>
     </article>

--- a/frontend/photo-filter-frontend/app/utils/library-image-url.ts
+++ b/frontend/photo-filter-frontend/app/utils/library-image-url.ts
@@ -1,0 +1,11 @@
+import config from 'photo-filter-frontend/config/environment';
+
+export function libraryImageUrl(filename?: string | null, options?: { host?: string | null }) {
+  if (!filename) return null;
+  const host = options?.host ?? (config.APP.apiHost as string | undefined) ?? '';
+  const normalizedHost = host.replace(/\/+$/, '');
+  const encoded = encodeURIComponent(filename);
+  return `${normalizedHost}/library/images/${encoded}`;
+}
+
+export default libraryImageUrl;


### PR DESCRIPTION
## Summary
- harden the /library/images middleware with stricter basename validation, correct 404 handling, and coverage tests
- align people index export filenames with the osxphotos export pipeline, include backward-compatible hero fallbacks, and enrich fixtures/tests for sort-aware heroes
- polish the people UI helpers with clearer naming and data-test hooks while keeping legacy hero selection behavior documented

## Testing
- npm --prefix backend test *(fails: jest binaries missing in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f768a102c8330b031e2222a17f5bf)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a secure /library/images endpoint and enriches the people index with sort-aware hero filenames/UUIDs and display fields, updating API, tests, and UI to consume them.
> 
> - **Backend**:
>   - **Library Images**: Add `GET /library/images/:exportedName` via `middleware/library-images.js` with strict basename validation, traversal checks, caching headers, and 404 handling; wire up in `app.js`.
>   - **People Index Export**: Revamp `scripts/export_people_index.py` to output `displayName`, sort-mode hero UUIDs, and exported basenames; atomic JSON writes; align filename template/JPEG ext via env.
>   - **People Summary API**: Update `utils/people-index.js` to pass env to Python exporter, improve name sorting, and pick `heroExportedName` based on sort; `people-controller` serializer exposes new fields and removes slug ID mapping.
>   - **Infra**: `run-python-script.js` supports env overrides; export `applyCachingHeaders` from `middleware/images.js`.
>   - **Tests/Fixtures**: Add `library-images.test.js` and expand `api.people-library.test.js` for hero selection; update `testdata/library/people-index.json`.
> - **Frontend**:
>   - **UI/Model**: Add `displayName` and hero/export fields to `person` model; implement sort selector, dynamic order label, and hero filename fallback logic in `people` controller/template.
>   - **Image URLs**: Introduce `library-image-url` util and helper; render hero images using new endpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2d116654139097d8a130cb4fbb24b293e6dff62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->