### PR TITLE
Fix people page rendering with explicit tile component

### DIFF
--- a/frontend/photo-filter-frontend/app/components/people/person-tile.hbs
+++ b/frontend/photo-filter-frontend/app/components/people/person-tile.hbs
@@ -1,0 +1,29 @@
+<article class="person-tile card bg-base-100 shadow">
+  <div class="card-body gap-3">
+    {{#if this.heroUrl}}
+      <img
+        src={{this.heroUrl}}
+        alt={{this.displayName}}
+        class="w-full rounded-xl object-cover aspect-square bg-base-300"
+        loading="lazy"
+      />
+    {{else}}
+      <div
+        class="w-full rounded-xl aspect-square bg-base-200 flex items-center justify-center text-sm text-base-content/60"
+      >
+        No image available
+      </div>
+    {{/if}}
+
+    <div class="person-meta space-y-1">
+      <h2 class="text-lg font-semibold person-name">{{this.displayName}}</h2>
+      <p class="text-sm opacity-80">{{@person.photoCount}} photos</p>
+
+      {{#if this.primaryDateValue}}
+        <p class="text-xs opacity-70">
+          {{this.primaryDateLabel}}: {{this.primaryDateValue}}
+        </p>
+      {{/if}}
+    </div>
+  </div>
+</article>

--- a/frontend/photo-filter-frontend/app/components/people/person-tile.ts
+++ b/frontend/photo-filter-frontend/app/components/people/person-tile.ts
@@ -1,0 +1,96 @@
+import Component from '@glimmer/component';
+import libraryImageUrl from 'photo-filter-frontend/utils/library-image-url';
+
+interface PersonTileArgs {
+  person: {
+    displayName?: string | null;
+    name?: string | null;
+    photoCount?: number | null;
+    earliestPhotoAt?: string | Date | null;
+    latestPhotoAt?: string | Date | null;
+    medianPhotoAt?: string | Date | null;
+    heroExportedName?: string | null;
+    earliestExportedName?: string | null;
+    medianExportedName?: string | null;
+    latestExportedName?: string | null;
+    highlightExportedName?: string | null;
+  } | null;
+  sort?: string;
+}
+
+export default class PeoplePersonTileComponent extends Component<PersonTileArgs> {
+  get person() {
+    return this.args.person;
+  }
+
+  get sort() {
+    return this.args.sort ?? 'medianPhotoAt';
+  }
+
+  get displayName() {
+    return (
+      this.person?.displayName || this.person?.name || 'Unnamed person'
+    );
+  }
+
+  get heroFilename(): string | null {
+    if (!this.person) {
+      return null;
+    }
+
+    if (this.person.heroExportedName) {
+      return this.person.heroExportedName;
+    }
+
+    if (this.sort === 'earliestPhotoAt') {
+      return (
+        this.person.earliestExportedName ?? this.person.heroExportedName ?? null
+      );
+    }
+
+    if (this.sort === 'latestPhotoAt') {
+      return this.person.latestExportedName ?? this.person.heroExportedName ?? null;
+    }
+
+    if (this.sort === 'photoCount' || this.sort === 'name') {
+      return (
+        this.person.highlightExportedName ?? this.person.heroExportedName ?? null
+      );
+    }
+
+    return this.person.medianExportedName ?? this.person.heroExportedName ?? null;
+  }
+
+  get heroUrl(): string | null {
+    const filename = this.heroFilename;
+    return filename ? libraryImageUrl(filename) : null;
+  }
+
+  get primaryDateLabel() {
+    if (this.sort === 'earliestPhotoAt') {
+      return 'Earliest';
+    }
+
+    if (this.sort === 'latestPhotoAt') {
+      return 'Latest';
+    }
+
+    return 'Median';
+  }
+
+  get primaryDateValue() {
+    if (!this.person) {
+      return null;
+    }
+
+    if (this.sort === 'earliestPhotoAt') {
+      return this.person.earliestPhotoAt;
+    }
+
+    if (this.sort === 'latestPhotoAt') {
+      return this.person.latestPhotoAt;
+    }
+
+    return this.person.medianPhotoAt;
+  }
+}

--- a/frontend/photo-filter-frontend/app/controllers/people.js
+++ b/frontend/photo-filter-frontend/app/controllers/people.js
@@ -30,32 +30,6 @@ export default class PeopleController extends Controller {
     return this.order === 'asc' ? 'Oldest → Newest' : 'Newest → Oldest';
   }
 
-  displayNameFor(person) {
-    return person.displayName || person.name || 'Unnamed person';
-  }
-
-  // Backend typically supplies a sort-aware heroExportedName; this helper keeps
-  // tests and older index files working by falling back to per-mode filenames.
-  heroFilenameFor(person) {
-    if (person.heroExportedName) {
-      return person.heroExportedName;
-    }
-
-    if (this.sort === 'earliestPhotoAt') {
-      return person.earliestExportedName || person.heroExportedName;
-    }
-
-    if (this.sort === 'latestPhotoAt') {
-      return person.latestExportedName || person.heroExportedName;
-    }
-
-    if (this.sort === 'photoCount' || this.sort === 'name') {
-      return person.highlightExportedName || person.heroExportedName;
-    }
-
-    return person.medianExportedName || person.heroExportedName;
-  }
-
   @action
   toggleOrder() {
     this.order = this.order === 'asc' ? 'desc' : 'asc';

--- a/frontend/photo-filter-frontend/app/templates/people.hbs
+++ b/frontend/photo-filter-frontend/app/templates/people.hbs
@@ -13,9 +13,12 @@
       {{on "change" this.updateSort}}
       value={{this.sort}}
     >
-      {{#each this.sortOptions as |option|}}
-        <option value={{option.value}} selected={{eq option.value this.sort}}>
-          {{option.label}}
+      {{#each this.sortOptions as |sortOption|}}
+        <option
+          value={{sortOption.value}}
+          selected={{eq sortOption.value this.sort}}
+        >
+          {{sortOption.label}}
         </option>
       {{/each}}
     </select>
@@ -33,37 +36,6 @@
 
 <section class="people-grid grid gap-4 md:grid-cols-2 lg:grid-cols-3">
   {{#each @model as |person|}}
-    <article class="person-tile card bg-base-100 shadow">
-      <div class="card-body gap-3">
-        {{#let (library-image-url (this.heroFilenameFor person)) as |heroUrl|}}
-          {{#if heroUrl}}
-            <img
-              src={{heroUrl}}
-              alt={{this.displayNameFor person}}
-              class="w-full rounded-xl object-cover aspect-square bg-base-300"
-              loading="lazy"
-            />
-          {{else}}
-            <div class="w-full rounded-xl aspect-square bg-base-200 flex items-center justify-center text-sm text-base-content/60">
-              No image available
-            </div>
-          {{/if}}
-        {{/let}}
-
-        <div class="person-meta space-y-1">
-          <h2 class="text-lg font-semibold person-name">{{this.displayNameFor person}}</h2>
-          <p class="text-sm opacity-80">{{person.photoCount}} photos</p>
-          <p class="text-xs opacity-70">
-            {{#if (eq this.sort "earliestPhotoAt")}}
-              Earliest: {{person.earliestPhotoAt}}
-            {{else if (eq this.sort "latestPhotoAt")}}
-              Latest: {{person.latestPhotoAt}}
-            {{else}}
-              Median: {{person.medianPhotoAt}}
-            {{/if}}
-          </p>
-        </div>
-      </div>
-    </article>
+    <People::PersonTile @person={{person}} @sort={{this.sort}} />
   {{/each}}
 </section>


### PR DESCRIPTION
## Summary
- render people records through a dedicated `People::PersonTile` component so we only ever pass real components into the template
- keep people sort controls while delegating display logic (names, hero images, date labels) into the new component
- tidy the people template by renaming the sort option block param for clarity

## Testing
- CI=true npm run test:ember -- --filter "People route lists" --module "Acceptance | people route" *(fails: Launcher Chrome not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fc81137f483309297c6213c30572c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces inline people tile rendering with a `People::PersonTile` component that encapsulates image/name/date logic, while keeping existing sort controls.
> 
> - **UI — People page**:
>   - **New component**: `People::PersonTile` (`.hbs` + `.ts`)
>     - Computes `displayName`, sort-aware hero image filename, `heroUrl` via `library-image-url`.
>     - Derives `primaryDateLabel`/`primaryDateValue` based on `@sort`.
>   - **Template**: `app/templates/people.hbs`
>     - Replaces inline tile markup with `<People::PersonTile @person={{person}} @sort={{this.sort}} />`.
>     - Renames sort option block param to `sortOption` for clarity.
>   - **Controller**: `app/controllers/people.js`
>     - Removes display helpers now handled by the component.
>     - Retains sort options and `toggleOrder`/`updateSort` actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452a75a63ea33981583f7a23079772e9c843291a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->