### PR TITLE
Slim album export payload and guard oversized photos.json

### DIFF
--- a/backend/scripts/export_photos_in_album.py
+++ b/backend/scripts/export_photos_in_album.py
@@ -3,8 +3,150 @@
 import json
 import os
 import sys
+from typing import Any, Iterable, Optional
 
 import osxphotos
+
+
+def normalize_date(value: Any):
+    if value is None:
+        return None
+    try:
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+    except Exception:
+        pass
+    try:
+        return str(value)
+    except Exception:
+        return None
+
+
+def safe_list(value: Any) -> list:
+    if isinstance(value, (list, tuple, set)):
+        return [item for item in value if item is not None]
+    return []
+
+
+def serialize_score(score: Any):
+    if score is None:
+        return None
+    if isinstance(score, dict):
+        return score
+    if hasattr(score, "_asdict"):
+        try:
+            return score._asdict()
+        except Exception:
+            pass
+    if hasattr(score, "asdict"):
+        try:
+            return score.asdict()
+        except Exception:
+            pass
+    if hasattr(score, "__dict__"):
+        try:
+            return {
+                key: value
+                for key, value in score.__dict__.items()
+                if not key.startswith("_")
+            }
+        except Exception:
+            pass
+    return score
+
+
+def slim_exif_info(exif_info: Any):
+    if exif_info is None:
+        return None
+    candidates = None
+    if isinstance(exif_info, dict):
+        candidates = exif_info
+    elif hasattr(exif_info, "_asdict"):
+        try:
+            candidates = exif_info._asdict()
+        except Exception:
+            candidates = None
+    elif hasattr(exif_info, "__dict__"):
+        candidates = exif_info.__dict__
+
+    if not candidates:
+        return None
+
+    subset = {}
+    for key in ("make", "model", "lens_model"):
+        if candidates.get(key) is not None:
+            subset[key] = candidates[key]
+    return subset or None
+
+
+def slim_photo(photo: Any):
+    face_info = []
+    for face in getattr(photo, "face_info", None) or []:
+        name = getattr(face, "name", None)
+        if name:
+            face_info.append({"name": name})
+
+    date_value = (
+        getattr(photo, "date", None)
+        or getattr(photo, "created", None)
+        or getattr(photo, "creation_date", None)
+        or getattr(photo, "creationDate", None)
+    )
+
+    return {
+        "uuid": getattr(photo, "uuid", None),
+        "original_filename": getattr(photo, "original_filename", None)
+        or getattr(photo, "filename", None),
+        "filename": getattr(photo, "filename", None),
+        "date": normalize_date(date_value),
+        "persons": safe_list(getattr(photo, "persons", None)),
+        "persons_full": safe_list(getattr(photo, "persons_full", None)),
+        "face_names": safe_list(getattr(photo, "face_names", None)),
+        "faceInfo": face_info,
+        "score": serialize_score(getattr(photo, "score", None)),
+        "exif_info": slim_exif_info(getattr(photo, "exif_info", None)),
+    }
+
+
+def ensure_uuid_file(pathname: str):
+    try:
+        directory = os.path.dirname(pathname) or "."
+        os.makedirs(directory, exist_ok=True)
+        return open(pathname, "w", encoding="utf-8")
+    except OSError as exc:
+        print(
+            f"Failed to open UUID output {pathname}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def stream_photos(photos: Iterable[Any], uuids_output_path: Optional[str] = None):
+    uuid_file = ensure_uuid_file(uuids_output_path) if uuids_output_path else None
+    try:
+        sys.stdout.write("[")
+        first = True
+        for photo in photos:
+            slimmed = slim_photo(photo)
+            if slimmed is None:
+                continue
+            if uuid_file and getattr(photo, "uuid", None):
+                uuid_file.write(f"{photo.uuid}\n")
+            if not first:
+                sys.stdout.write(",")
+            json.dump(
+                slimmed,
+                sys.stdout,
+                default=str,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            )
+            first = False
+        sys.stdout.write("]\n")
+    finally:
+        if uuid_file:
+            uuid_file.close()
+
 
 def main():
     if len(sys.argv) < 2:
@@ -26,29 +168,11 @@ def main():
         print(f"Album with UUID {album_uuid} not found.", file=sys.stderr)
         sys.exit(1)
 
-    # Get photos in the album
     photos = album.photos
 
-    # Convert photo objects to dictionaries
-    photos_data = [photo.asdict() for photo in photos]
+    # Output the data as JSON, handling datetime objects without pretty-printing
+    stream_photos(photos, uuids_output_path)
 
-    if uuids_output_path:
-        try:
-            directory = os.path.dirname(uuids_output_path) or "."
-            os.makedirs(directory, exist_ok=True)
-            with open(uuids_output_path, "w", encoding="utf-8") as fh:
-                for photo in photos:
-                    if getattr(photo, "uuid", None):
-                        fh.write(f"{photo.uuid}\n")
-        except OSError as exc:
-            print(
-                f"Failed to write UUIDs to {uuids_output_path}: {exc}",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-    # Output the data as JSON, handling datetime objects
-    print(json.dumps(photos_data, indent=4, default=str))
 
 if __name__ == "__main__":
     main()

--- a/backend/utils/prepare-album.js
+++ b/backend/utils/prepare-album.js
@@ -52,15 +52,16 @@ async function prepareAlbumInternal(context) {
   const status = await loadStatus(albumUUID, { exportBase, photosJSON });
   const hasPhotos = await fs.pathExists(photosJSON);
 
-  if (hasPhotos && status.status === "ready") {
-    return status;
-  }
-
-  if (hasPhotos && status.status !== "ready") {
-    return await writeStatus(albumUUID, exportBase, {
-      status: "ready",
-      finishedAt: status.finishedAt || new Date().toISOString(),
-    });
+  if (hasPhotos) {
+    if (status.status === "ready" || status.status === "skipped-empty") {
+      return status;
+    }
+    if (status.status && status.status !== "error") {
+      return await writeStatus(albumUUID, exportBase, {
+        status: "ready",
+        finishedAt: status.finishedAt || new Date().toISOString(),
+      });
+    }
   }
 
   const startedAt = new Date().toISOString();
@@ -128,6 +129,12 @@ async function prepareAlbumInternal(context) {
       lastProgressAt: progressTimestamp,
       lastHeartbeatAt: progressTimestamp,
     });
+    const { size: photosSize } = await fs.stat(photosJSON);
+    if (photosSize > 512 * 1024 * 1024) {
+      const message = `photos.json too large to process (${formatBytes(photosSize)})`;
+      logMessage(message);
+      throw new Error(message);
+    }
     const photos = await fs.readJson(photosJSON);
     const uuids = await loadUuidsFromFile(uuidsFile);
     let exportResult = null;
@@ -285,6 +292,20 @@ function formatExtra(extra) {
   } catch {
     return String(extra);
   }
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return String(bytes);
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const formatted =
+    value >= 10 || value % 1 === 0 ? value.toFixed(0) : value.toFixed(1);
+  return `${formatted} ${units[unitIndex]}`;
 }
 
 function startStatusHeartbeat(albumUUID, exportBase, intervalMs = 15000) {


### PR DESCRIPTION
## Summary
- stream a trimmed photo payload from the album export script to keep photos.json compact and include only needed fields
- write UUIDs alongside the streamed export output while dropping pretty printing and unused metadata
- avoid auto-marking errored albums as ready and fail early when photos.json is oversized during prepare

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957104204908330b43b7b22ab4236af)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Backend export script now streams compact JSON to `stdout` via `stream_photos`, emitting only selected fields from `slim_photo` (e.g., `uuid`, filenames, normalized `date`, people, minimal `exif_info`, `score`) and writes UUIDs to `uuids.txt` concurrently.
> - Removed full `asdict()` payload and pretty-printing; output uses ASCII-disabled, compact separators for smaller `photos.json`.
> - `prepare-album.js` updates status logic to respect `skipped-empty` and avoid auto-marking `error` runs as ready.
> - Adds size check after export (`fs.stat` on `photos.json`) and throws if > `512 MB`, with human-readable bytes via `formatBytes`.
> - Minor: logs/heartbeat maintained; `.skipped-empty` handling and manifest/materialization flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 976e4267c290078c6752f50f06939b4b29a6235a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->